### PR TITLE
FS-597 zap exit on fail

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -26,9 +26,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  FORMS_SERVICE_PREVIEW_HOST: "https://funding-service-design-form-runner.london.cloudapps.digital"
-  FORMS_SERVICE_PUBLIC_HOST: "https://funding-service-design-form-runner.london.cloudapps.digital"
-  FORMS_SERVICE_HOST: "https://funding-service-design-form-runner.london.cloudapps.digital"
+  FORMS_SERVICE_PREVIEW_HOST: ${{ secrets.FORMS_SERVICE_HOST}}
+  FORMS_SERVICE_PUBLIC_HOST: ${{ secrets.FORMS_SERVICE_HOST}}
+  FORMS_SERVICE_HOST: ${{ secrets.FORMS_SERVICE_HOST}}
 
 
 jobs:
@@ -126,3 +126,9 @@ jobs:
           name: accessibility-test-report
           path: /home/runner/work/funding-service-design-frontend/funding-service-design-frontend/axe_reports/*.html
           retention-days: 5
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.3.0
+        with:
+          target: ${{ secrets.FORMS_SERVICE_HOST }}
+          allow_issue_writing: False
+          fail_action: true


### PR DESCRIPTION
A holding PR for additions that can be reintroduced when the XGovFormsBuilder service dependency has a passing ZAP scan security test in its pipeline.

For full details see [Issue #28](https://github.com/communitiesuk/funding-service-design-frontend/issues/28)