### PR TITLE
FS-877: add landing page

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,7 @@
 from os import environ
 from os import path
 
-TEST_APPLICATION_STORE_API_HOST = "application_store"
+TEST_APPLICATION_STORE_API_HOST = "http://application_store"
 
 """
 Application Config

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -1,4 +1,6 @@
+from app.filters import datetime_format
 from flask import Flask
+from flask_babel import Babel
 from flask_compress import Compress
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
@@ -11,6 +13,7 @@ def create_app() -> Flask:
     flask_app = Flask(__name__, static_url_path="/assets")
 
     flask_app.config.from_pyfile("config.py")
+    Babel(flask_app)
 
     flask_app.jinja_loader = ChoiceLoader(
         [
@@ -23,6 +26,7 @@ def create_app() -> Flask:
 
     flask_app.jinja_env.trim_blocks = True
     flask_app.jinja_env.lstrip_blocks = True
+    flask_app.jinja_env.add_extension("jinja2.ext.i18n")
 
     csp = {
         "default-src": "'self'",
@@ -75,6 +79,7 @@ def create_app() -> Flask:
     flask_app.register_error_handler(404, not_found)
     flask_app.register_error_handler(500, internal_server_error)
     flask_app.register_blueprint(default_bp)
+    flask_app.jinja_env.filters["datetime_format"] = datetime_format
 
     return flask_app
 

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -46,6 +46,15 @@ def new(account_id):
             "fund_id": request.form["fund_id"],
         },
     )
+    new_application_json = new_application.json()
+    if new_application.status_code != 201 or not new_application_json.get(
+        "id"
+    ):
+        raise Exception(
+            "Unexpected response from application store when creating new"
+            " application: "
+            + str(new_application.status_code)
+        )
     return redirect(
         url_for(
             "routes.tasklist", application_id=new_application.json().get("id")

--- a/app/filters.py
+++ b/app/filters.py
@@ -1,0 +1,2 @@
+def datetime_format(value, format="%d/%m/%y"):
+    return value.strftime(format)

--- a/app/models/application_summary.py
+++ b/app/models/application_summary.py
@@ -1,0 +1,34 @@
+import inspect
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class ApplicationSummary:
+    id: str
+    status: str
+    round_id: str
+    fund_id: str
+    started_at: datetime
+    project_name: str
+    last_edited: Optional[datetime] = None
+
+    def __post_init__(self):
+        self.started_at = datetime.fromisoformat(self.started_at)
+        self.last_edited = (
+            datetime.fromisoformat(self.last_edited)
+            if self.last_edited
+            else None
+        )
+
+    @classmethod
+    def from_dict(cls, d: dict):
+        # Filter unknown fields from JSON dictionary
+        return cls(
+            **{
+                k: v
+                for k, v in d.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,67 @@
+{%- from "govuk_frontend_jinja/components/tag/macro.html" import govukTag -%}
+{%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{% extends "base.html" %}
+{% block content %}
+    <h1 class="govuk-heading-xl">Your applications</h1>
+    <p class="govuk-body">
+        You have started {% trans count=applications|length %} {{ count }} application {% pluralize %} {{ count }} applications {% endtrans %} using this email address.
+    </p>
+    {% set ns = namespace(rows = []) %}
+    {% for application in applications %}
+        {% set status_class %}
+        {%  if application.status == 'COMPLETED' %}
+            govuk-tag--green
+        {%  elif application.status == 'NOT_STARTED' %}
+            govuk-tag--red
+        {% endif %}
+    {% endset %}
+    {% set row = ns.rows.append(
+    [
+    {
+    'html': '<a class="govuk-link" href="{}">{}</a>'.format(url_for('routes.tasklist', application_id=application.id), application.project_name if application.project_name else 'Untitled project')
+    },
+    {
+    'text':  govukTag({
+    'text': application.status|replace('_',' ') ,
+    'classes': status_class
+    })
+    },
+    {
+    'text': application.started_at|datetime_format
+    },
+    {
+    'text': application.last_edited|datetime_format if application.last_edited
+    }
+    ]
+    ) %}
+{% endfor %}
+{{ govukTable({
+'head': [
+{
+'text': 'Project name'
+},
+{
+'text': 'Status'
+},
+{
+'text': 'Started on'
+},
+{
+'text': 'Last edited'
+}
+],
+'rows': ns.rows
+}) }}
+<form method="POST" action={{ url_for('routes.new', account_id=account_id) }}>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="account_id" value="{{ account_id }}">
+    <input type="hidden" name="fund_id" value="{{ applications[0]['fund_id'] }}">
+    <input type="hidden"
+           name="round_id"
+           value="{{ applications[0]['round_id'] }}">
+    {{ govukButton({
+    'text': "Start new application"
+    }) }}
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ distlib==0.3.4
 dparse==0.5.1
 filelock==3.4.2
 Flask==2.0.2
+Flask-Babel==2.0.0
 Flask-Compress==1.10.1
 Flask-SeaSurf==0.3.1
 flask-talisman==0.8.1
@@ -55,6 +56,7 @@ python-dotenv==0.19.2
 python-slugify==6.1.2
 PyYAML==6.0
 requests==2.27.1
+requests-mock==1.9.3
 safety==1.10.3
 selenium==4.1.0
 six==1.16.0

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -1,5 +1,5 @@
 {
-    "application_store/applications/test_id": {
+    "http://application_store/applications/test_id": {
         "application_id": "test_id",
         "account_id": "AccountA",
         "round_id": "Round Two",

--- a/tests/test_application_summary.py
+++ b/tests/test_application_summary.py
@@ -1,0 +1,55 @@
+import json
+
+from app.models.application_summary import ApplicationSummary
+
+
+TEST_APPLICATION_STORE_DATA = """[
+    {
+        "id": "uuidv4",
+        "status": "IN_PROGRESS",
+        "account_id": "test-user",
+        "fund_id": "funding-service-design",
+        "round_id": "summer",
+        "project_name": null,
+        "date_submitted": null,
+        "started_at": "2022-05-20 14:47:12",
+        "last_edited": "2022-05-24 11:03:59"
+    },
+    {
+        "id": "ed221ac8-5d4d-42dd-ab66-6cbcca8fe257",
+        "status": "NOT_STARTED",
+        "account_id": "test-user",
+        "fund_id": "funding-service-design",
+        "round_id": "summer",
+        "project_name": "",
+        "date_submitted": null,
+        "started_at": "2022-05-24 10:42:41",
+        "last_edited": null,
+        "Unknown": "DOES NOT MAKE ME FAIL"
+    }
+]"""
+
+
+def test_serialise_application_summary():
+    application_list = json.loads(TEST_APPLICATION_STORE_DATA)
+
+    applications = [
+        ApplicationSummary.from_dict(application)
+        for application in application_list
+    ]
+    assert len(applications) == 2
+    assert applications[0].started_at.__class__.__name__ == "datetime"
+    assert applications[1].last_edited is None
+
+
+def test_dashboard_route(flask_test_client, requests_mock):
+    requests_mock.get(
+        "http://application_store/applications?account_id=test-user",
+        text=TEST_APPLICATION_STORE_DATA,
+    )
+    response = flask_test_client.get(
+        "/account/test-user", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert b"IN PROGRESS" in response.data
+    assert b"20/05/22" in response.data


### PR DESCRIPTION
Add dashboard which reads from the application store to get existing applications and POSTs to application store to create new applications 

Note: This reads account ID from a path param which should be replaced once we can read it from the session. Also this assumes there will always be at least one application created, as it relies on params of the existing application to derive the fund and round of the new one (let me know if there's a better way to derive this
![Screenshot 2022-05-24 at 14 46 37](https://user-images.githubusercontent.com/1764158/170056690-f2e7511b-d539-4334-ada5-a981f196ded2.png)
