### PR TITLE
BAU: Set force HTTPS to false on Talisman config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -48,7 +48,10 @@ def create_app() -> Flask:
 
     Compress(flask_app)
     Talisman(
-        flask_app, content_security_policy=csp, strict_transport_security=hss
+        flask_app,
+        content_security_policy=csp,
+        strict_transport_security=hss,
+        force_https=False,
     )
 
     csrf = CSRFProtect()


### PR DESCRIPTION
Locally this causes problems as we don't have HTTPS and remotely it is unnecessary as PaaS enforces HTTPS
