### PR TITLE
BAU: default fund and round id if non existing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,9 +4,9 @@ from os import path
 
 TEST_APPLICATION_STORE_API_HOST = "http://application_store"
 
-"""
-Application Config
-"""
+
+# Application Config
+
 SECRET_KEY = environ.get("SECRET_KEY") or "dev"
 SESSION_COOKIE_NAME = environ.get("SESSION_COOKIE_NAME") or "session_cookie"
 STATIC_FOLDER = "static"
@@ -14,9 +14,9 @@ TEMPLATES_FOLDER = "templates"
 LOCAL_SERVICE_NAME = "local_flask"
 FLASK_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
 
-"""
-Forms Service Config
-"""
+
+# Forms Service Config
+
 FORMS_SERVICE_NAME = environ.get("FORMS_SERVICE_NAME") or "xgov_forms_service"
 FORMS_SERVICE_PUBLIC_HOST = (
     environ.get("FORMS_SERVICE_PUBLIC_HOST") or "http://localhost:3009"
@@ -34,9 +34,9 @@ FORM_REHYDRATION_URL = (
     FORMS_SERVICE_PUBLIC_HOST + "/session/{rehydration_token}"
 )
 
-"""
-Application Store Service Config
-"""
+
+# Application Store Service Config
+
 APPLICATION_STORE_API_HOST = (
     environ.get("APPLICATION_STORE_API_HOST")
     or TEST_APPLICATION_STORE_API_HOST
@@ -50,3 +50,6 @@ UPDATE_APPLICATION_SECTION_ENDPOINT = (
 SUBMIT_APPLICATION_ENDPOINT = (
     APPLICATION_STORE_API_HOST + "/applications/{application_id}/submit"
 )
+
+DEFAULT_FUND_ID = "funding-service-design"
+DEFAULT_ROUND_ID = "summer"

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -1,4 +1,5 @@
 import requests
+from app import config
 from app.config import APPLICATION_STORE_API_HOST
 from app.config import FORM_REHYDRATION_URL
 from app.config import FORMS_SERVICE_PUBLIC_HOST
@@ -31,8 +32,18 @@ def dashboard(account_id):
     applications: list[ApplicationSummary] = [
         ApplicationSummary.from_dict(application) for application in response
     ]
+    if len(applications) > 0:
+        round_id = applications[0].round_id
+        fund_id = applications[0].fund_id
+    else:
+        round_id = config.DEFAULT_ROUND_ID
+        fund_id = config.DEFAULT_FUND_ID
     return render_template(
-        "dashboard.html", account_id=account_id, applications=applications
+        "dashboard.html",
+        account_id=account_id,
+        applications=applications,
+        round_id=round_id,
+        fund_id=fund_id,
     )
 
 
@@ -42,8 +53,8 @@ def new(account_id):
         url=f"{APPLICATION_STORE_API_HOST}/applications",
         json={
             "account_id": account_id,
-            "round_id": request.form["round_id"],
-            "fund_id": request.form["fund_id"],
+            "round_id": request.form["round_id"] or config.DEFAULT_ROUND_ID,
+            "fund_id": request.form["fund_id"] or config.DEFAULT_FUND_ID,
         },
     )
     new_application_json = new_application.json()

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -36,30 +36,30 @@
     ]
     ) %}
 {% endfor %}
-{{ govukTable({
-'head': [
-{
-'text': 'Project name'
-},
-{
-'text': 'Status'
-},
-{
-'text': 'Started on'
-},
-{
-'text': 'Last edited'
-}
-],
-'rows': ns.rows
-}) }}
+{% if applications|length > 0 %}
+    {{ govukTable({
+    'head': [
+    {
+    'text': 'Project name'
+    },
+    {
+    'text': 'Status'
+    },
+    {
+    'text': 'Started on'
+    },
+    {
+    'text': 'Last edited'
+    }
+    ],
+    'rows': ns.rows
+    }) }}
+{% endif %}
 <form method="POST" action={{ url_for('routes.new', account_id=account_id) }}>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="hidden" name="account_id" value="{{ account_id }}">
-    <input type="hidden" name="fund_id" value="{{ applications[0]['fund_id'] }}">
-    <input type="hidden"
-           name="round_id"
-           value="{{ applications[0]['round_id'] }}">
+    <input type="hidden" name="fund_id" value="{{ fund_id }}">
+    <input type="hidden" name="round_id" value="{{ round_id }}">
     {{ govukButton({
     'text': "Start new application"
     }) }}

--- a/tests/test_application_summary.py
+++ b/tests/test_application_summary.py
@@ -53,3 +53,15 @@ def test_dashboard_route(flask_test_client, requests_mock):
     assert response.status_code == 200
     assert b"IN PROGRESS" in response.data
     assert b"20/05/22" in response.data
+
+
+def test_dashboard_route_no_applications(flask_test_client, requests_mock):
+    requests_mock.get(
+        "http://application_store/applications?account_id=test-user",
+        text="[]",
+    )
+    response = flask_test_client.get(
+        "/account/test-user", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert b"Start new application" in response.data


### PR DESCRIPTION
Previously we did not handle the case of no existing applications, which can happen depending on the route by which the user arrives at the frontend.
