### PR TITLE
FS-989: read auth token and protect routes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,3 +53,4 @@ SUBMIT_APPLICATION_ENDPOINT = (
 
 DEFAULT_FUND_ID = "funding-service-design"
 DEFAULT_ROUND_ID = "summer"
+FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 """Flask configuration."""
+import os
 from os import environ
 from os import path
 
@@ -38,9 +39,10 @@ FORM_REHYDRATION_URL = (
 # Application Store Service Config
 
 APPLICATION_STORE_API_HOST = (
-    environ.get("APPLICATION_STORE_API_HOST")
-    or TEST_APPLICATION_STORE_API_HOST
+    environ.get("APPLICATION_STORE_API_HOST", TEST_APPLICATION_STORE_API_HOST)
 )
+  
+
 GET_APPLICATION_ENDPOINT = (
     APPLICATION_STORE_API_HOST + "/applications/{application_id}"
 )
@@ -54,3 +56,15 @@ SUBMIT_APPLICATION_ENDPOINT = (
 DEFAULT_FUND_ID = "funding-service-design"
 DEFAULT_ROUND_ID = "summer"
 FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
+
+RSA256_PUBLIC_KEY = (
+    environ.get("RSA256_PUBLIC_KEY")
+    or """# This is public key used for testing only
+-----BEGIN PUBLIC KEY-----
+MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgHGbtF1yVGW+rCAFOIdakUVwCfuv
+xHE38lE/i0KWpMwdSHZFFLYnHjBVOOh15EiizYza4FTJTMvL2E4QrLpqYj6KE6tv
+HrhyP/N5fypSzt8vCj9spZ8+0kFucW9zyMkPuDisYtmkWGdxBmkd3gtYp3mOI53V
+VDgKbtoIFU3sIk5NAgMBAAE=
+-----END PUBLIC KEY-----
+"""
+)

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,4 @@
 """Flask configuration."""
-import os
 from os import environ
 from os import path
 
@@ -38,10 +37,10 @@ FORM_REHYDRATION_URL = (
 
 # Application Store Service Config
 
-APPLICATION_STORE_API_HOST = (
-    environ.get("APPLICATION_STORE_API_HOST", TEST_APPLICATION_STORE_API_HOST)
+APPLICATION_STORE_API_HOST = environ.get(
+    "APPLICATION_STORE_API_HOST", TEST_APPLICATION_STORE_API_HOST
 )
-  
+
 
 GET_APPLICATION_ENDPOINT = (
     APPLICATION_STORE_API_HOST + "/applications/{application_id}"
@@ -57,10 +56,7 @@ DEFAULT_FUND_ID = "funding-service-design"
 DEFAULT_ROUND_ID = "summer"
 FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
 
-AUTHENTICATOR_HOST = (
-    environ.get("AUTHENTICATOR_HOST"),
-    "http://localhost:3004",
-)
+AUTHENTICATOR_HOST = environ.get("AUTHENTICATOR_HOST", "http://localhost:3004")
 
 RSA256_PUBLIC_KEY = environ.get(
     "RSA256_PUBLIC_KEY",

--- a/app/config.py
+++ b/app/config.py
@@ -57,14 +57,19 @@ DEFAULT_FUND_ID = "funding-service-design"
 DEFAULT_ROUND_ID = "summer"
 FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"
 
-RSA256_PUBLIC_KEY = (
-    environ.get("RSA256_PUBLIC_KEY")
-    or """# This is public key used for testing only
+AUTHENTICATOR_HOST = (
+    environ.get("AUTHENTICATOR_HOST"),
+    "http://localhost:3004",
+)
+
+RSA256_PUBLIC_KEY = environ.get(
+    "RSA256_PUBLIC_KEY",
+    """# This is public key used for testing only
 -----BEGIN PUBLIC KEY-----
 MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgHGbtF1yVGW+rCAFOIdakUVwCfuv
 xHE38lE/i0KWpMwdSHZFFLYnHjBVOOh15EiizYza4FTJTMvL2E4QrLpqYj6KE6tv
 HrhyP/N5fypSzt8vCj9spZ8+0kFucW9zyMkPuDisYtmkWGdxBmkd3gtYp3mOI53V
 VDgKbtoIFU3sIk5NAgMBAAE=
 -----END PUBLIC KEY-----
-"""
+""",
 )

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -8,6 +8,7 @@ from app.models.application_summary import ApplicationSummary
 from app.models.continue_application import continue_form_section
 from app.models.eligibility_questions import minimium_money_question_page
 from app.models.tasklist import tasklist_page
+from app.security.decorator import token_required
 from flask import Blueprint
 from flask import redirect
 from flask import render_template
@@ -25,6 +26,7 @@ def index():
 
 
 @default_bp.route("/account/<account_id>")
+@token_required
 def dashboard(account_id):
     response = requests.get(
         f"{APPLICATION_STORE_API_HOST}/applications?account_id={account_id}"
@@ -83,6 +85,7 @@ def not_eligible():
     return render_template("not_eligible.html")
 
 
+@token_required
 @default_bp.route("/tasklist/<application_id>", methods=["GET"])
 def tasklist(application_id):
     return tasklist_page(application_id)

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -8,7 +8,7 @@ from app.models.application_summary import ApplicationSummary
 from app.models.continue_application import continue_form_section
 from app.models.eligibility_questions import minimium_money_question_page
 from app.models.tasklist import tasklist_page
-from app.security.decorator import token_required
+from app.security.decorator import login_required
 from flask import Blueprint
 from flask import redirect
 from flask import render_template
@@ -25,8 +25,8 @@ def index():
     )
 
 
-@default_bp.route("/account/<account_id>")
-@token_required
+@default_bp.route("/account")
+@login_required
 def dashboard(account_id):
     response = requests.get(
         f"{APPLICATION_STORE_API_HOST}/applications?account_id={account_id}"
@@ -49,7 +49,8 @@ def dashboard(account_id):
     )
 
 
-@default_bp.route("/account/<account_id>/new", methods=["POST"])
+@default_bp.route("/account/new", methods=["POST"])
+@login_required
 def new(account_id):
     new_application = requests.post(
         url=f"{APPLICATION_STORE_API_HOST}/applications",
@@ -85,7 +86,7 @@ def not_eligible():
     return render_template("not_eligible.html")
 
 
-@token_required
+@login_required
 @default_bp.route("/tasklist/<application_id>", methods=["GET"])
 def tasklist(application_id):
     return tasklist_page(application_id)

--- a/app/public.pem
+++ b/app/public.pem
@@ -1,0 +1,7 @@
+# This is public key used for testing only
+-----BEGIN PUBLIC KEY-----
+MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgHGbtF1yVGW+rCAFOIdakUVwCfuv
+xHE38lE/i0KWpMwdSHZFFLYnHjBVOOh15EiizYza4FTJTMvL2E4QrLpqYj6KE6tv
+HrhyP/N5fypSzt8vCj9spZ8+0kFucW9zyMkPuDisYtmkWGdxBmkd3gtYp3mOI53V
+VDgKbtoIFU3sIk5NAgMBAAE=
+-----END PUBLIC KEY-----

--- a/app/public.pem
+++ b/app/public.pem
@@ -1,7 +1,0 @@
-# This is public key used for testing only
------BEGIN PUBLIC KEY-----
-MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgHGbtF1yVGW+rCAFOIdakUVwCfuv
-xHE38lE/i0KWpMwdSHZFFLYnHjBVOOh15EiizYza4FTJTMvL2E4QrLpqYj6KE6tv
-HrhyP/N5fypSzt8vCj9spZ8+0kFucW9zyMkPuDisYtmkWGdxBmkd3gtYp3mOI53V
-VDgKbtoIFU3sIk5NAgMBAAE=
------END PUBLIC KEY-----

--- a/app/security/decorator.py
+++ b/app/security/decorator.py
@@ -1,0 +1,28 @@
+from functools import wraps
+
+from app import config
+from app.security.utils import validate_token
+from flask import abort
+from flask import request
+
+
+def _check_access_token():
+    login_cookie = request.cookies.get(config.FSD_USER_TOKEN_COOKIE_NAME)
+    if login_cookie:
+        valid_token = validate_token(login_cookie)
+        return valid_token
+    else:
+        return abort(403)
+
+
+def token_required(f):
+    """Execute function if request contains valid access token."""
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token_payload = _check_access_token()
+        for name, val in token_payload.items():
+            setattr(decorated, name, val)
+        return f(*args, **kwargs)
+
+    return decorated

--- a/app/security/decorator.py
+++ b/app/security/decorator.py
@@ -15,14 +15,14 @@ def _check_access_token():
         return abort(403)
 
 
-def token_required(f):
-    """Execute function if request contains valid access token."""
+def login_required(f):
+    """Execute function if request contains valid JWT
+    and pass account_id to route."""
 
     @wraps(f)
     def decorated(*args, **kwargs):
         token_payload = _check_access_token()
-        for name, val in token_payload.items():
-            setattr(decorated, name, val)
+        kwargs["account_id"] = token_payload.get("accountId")
         return f(*args, **kwargs)
 
     return decorated

--- a/app/security/decorator.py
+++ b/app/security/decorator.py
@@ -4,18 +4,23 @@ from app import config
 from app.security.utils import validate_token
 from flask import redirect
 from flask import request
+from jwt import ExpiredSignatureError
+
+
+def _failed_redirect():
+    return redirect(
+        f"{config.AUTHENTICATOR_HOST}/magic-links/"
+        "new?error=Link+expired+or+invalid"
+    )
 
 
 def _check_access_token():
+
     login_cookie = request.cookies.get(config.FSD_USER_TOKEN_COOKIE_NAME)
-    if login_cookie:
-        valid_token = validate_token(login_cookie)
-        return valid_token
-    else:
-        return redirect(
-            f"{config.AUTHENTICATOR_HOST}/magic-links/"
-            f"new?return_url={request.url}"
-        )
+    if not login_cookie:
+        return _failed_redirect()
+
+    return validate_token(login_cookie)
 
 
 def login_required(f):
@@ -24,7 +29,10 @@ def login_required(f):
 
     @wraps(f)
     def decorated(*args, **kwargs):
-        token_payload = _check_access_token()
+        try:
+            token_payload = _check_access_token()
+        except ExpiredSignatureError:
+            return _failed_redirect()
         kwargs["account_id"] = token_payload.get("accountId")
         return f(*args, **kwargs)
 

--- a/app/security/decorator.py
+++ b/app/security/decorator.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from app import config
 from app.security.utils import validate_token
+from flask import abort
 from flask import redirect
 from flask import request
 from jwt import ExpiredSignatureError
@@ -9,18 +10,23 @@ from jwt import ExpiredSignatureError
 
 def _failed_redirect():
     return redirect(
-        f"{config.AUTHENTICATOR_HOST}/magic-links/"
-        "new?error=Link+expired+or+invalid"
+        abort(
+            redirect(
+                f"{config.AUTHENTICATOR_HOST}/magic-links/"
+                "new?error=Link+expired+or+invalid"
+            )
+        )
     )
 
 
 def _check_access_token():
-
     login_cookie = request.cookies.get(config.FSD_USER_TOKEN_COOKIE_NAME)
     if not login_cookie:
+        _failed_redirect()
+    try:
+        return validate_token(login_cookie)
+    except ExpiredSignatureError:
         return _failed_redirect()
-
-    return validate_token(login_cookie)
 
 
 def login_required(f):
@@ -29,10 +35,7 @@ def login_required(f):
 
     @wraps(f)
     def decorated(*args, **kwargs):
-        try:
-            token_payload = _check_access_token()
-        except ExpiredSignatureError:
-            return _failed_redirect()
+        token_payload = _check_access_token()
         kwargs["account_id"] = token_payload.get("accountId")
         return f(*args, **kwargs)
 

--- a/app/security/decorator.py
+++ b/app/security/decorator.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from app import config
 from app.security.utils import validate_token
-from flask import abort
+from flask import redirect
 from flask import request
 
 
@@ -12,7 +12,10 @@ def _check_access_token():
         valid_token = validate_token(login_cookie)
         return valid_token
     else:
-        return abort(403)
+        return redirect(
+            f"{config.AUTHENTICATOR_HOST}/magic-links/"
+            f"new?return_url={request.url}"
+        )
 
 
 def login_required(f):

--- a/app/security/utils.py
+++ b/app/security/utils.py
@@ -1,0 +1,6 @@
+import jwt as jwt
+from app import config
+
+
+def validate_token(token):
+    return jwt.decode(token, config.RSA256_PUBLIC_KEY, algorithms=["RS256"])

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -55,7 +55,7 @@
     'rows': ns.rows
     }) }}
 {% endif %}
-<form method="POST" action={{ url_for('routes.new', account_id=account_id) }}>
+<form method="POST" action={{ url_for('routes.new') }}>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="hidden" name="account_id" value="{{ account_id }}">
     <input type="hidden" name="fund_id" value="{{ fund_id }}">

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ pluggy==1.0.0
 pre-commit==2.16.0
 py==1.11.0
 pycparser==2.21
+PyJWT[crypto]==2.4.0
 pyOpenSSL==22.0.0
 pyparsing==3.0.6
 pytest==6.2.5

--- a/tests/test_application_summary.py
+++ b/tests/test_application_summary.py
@@ -42,14 +42,16 @@ def test_serialise_application_summary():
     assert applications[1].last_edited is None
 
 
-def test_dashboard_route(flask_test_client, requests_mock):
+def test_dashboard_route(flask_test_client, requests_mock, monkeypatch):
+    monkeypatch.setattr(
+        "app.security.decorator._check_access_token",
+        lambda: {"accountId": "test-user"},
+    )
     requests_mock.get(
         "http://application_store/applications?account_id=test-user",
         text=TEST_APPLICATION_STORE_DATA,
     )
-    response = flask_test_client.get(
-        "/account/test-user", follow_redirects=True
-    )
+    response = flask_test_client.get("/account", follow_redirects=True)
     assert response.status_code == 200
     assert b"IN PROGRESS" in response.data
     assert b"20/05/22" in response.data

--- a/tests/test_application_summary.py
+++ b/tests/test_application_summary.py
@@ -57,13 +57,18 @@ def test_dashboard_route(flask_test_client, requests_mock, monkeypatch):
     assert b"20/05/22" in response.data
 
 
-def test_dashboard_route_no_applications(flask_test_client, requests_mock):
+def test_dashboard_route_no_applications(
+    flask_test_client, requests_mock, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.security.decorator._check_access_token",
+        lambda: {"accountId": "test-user"},
+    )
+
     requests_mock.get(
         "http://application_store/applications?account_id=test-user",
         text="[]",
     )
-    response = flask_test_client.get(
-        "/account/test-user", follow_redirects=True
-    )
+    response = flask_test_client.get("/account", follow_redirects=True)
     assert response.status_code == 200
     assert b"Start new application" in response.data


### PR DESCRIPTION
This PR enforces authorisation by parsing the JWT token from the cookie set by the authenticator app and passing the `account_id` through to protected routes.

I believe for this to work in production we would need:
* JWT public key set for Frontend on PaaS
* Cookie domain setting to allow x-app sharing e.g. for dev `.cloudapps.digital`