### PR TITLE
BAU: limit test deploys to main branch

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -222,6 +222,7 @@ jobs:
 
   deploy_test:
     needs: security
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: test
     steps:


### PR DESCRIPTION
Same change as https://github.com/communitiesuk/funding-design-service-workflows/pull/6

We need to apply this separately as this repo has forked the shared deployment workflow.