### PR TITLE
BAU: Fix tests (unfix chromedriver version)

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -158,9 +158,6 @@ jobs:
         uses: browser-actions/setup-chrome@latest
       - name: setup Chromedriver
         uses: nanasess/setup-chromedriver@v1
-        with:
-          # Optional: do not specify to match Chrome's version
-          chromedriver-version: "101.0.4951.41"
       - name: Run tests
         run: pytest --driver Chrome --driver-path .venv/lib/python3.10/site-packages/chromedriver_py/chromedriver_linux64
       - name: "Upload Accessibility Testing reports"


### PR DESCRIPTION
Previously the chromedriver version was fixed in the tests whilst the version of chrome was the latest, this created a mismatch where the test would no longer run: 
e.g.
```
E       selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 100
E       Current browser version is 102.0.5005.61 with binary path /usr/bin/google-chrome
```
this fixes by unfixing the version of chromedriver used by github actions so it always downloads the latest version.
