### PR TITLE
BAU: fix slugify import

### DIFF
--- a/app/models/helpers.py
+++ b/app/models/helpers.py
@@ -1,6 +1,6 @@
 import requests
-import slugify
 from config import Config
+from slugify import slugify
 
 
 def get_token_to_return_to_application(form_name: str, rehydrate_payload):


### PR DESCRIPTION
Spotted in the course of another story.

We were getting a 500 on the `continue_application` route because `slugify` was not being imported correctly and we were attempting to call the module directly
![Screenshot 2022-07-11 at 10 24 59](https://user-images.githubusercontent.com/1764158/178233311-8acf12b3-0a7e-463f-aafc-d9a75b91982b.png)

