### PR TITLE
BAU: ignore application tests whilst form runner is unavailable

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -171,7 +171,8 @@ jobs:
       - name: Install Chromium
         uses: browser-actions/setup-chrome@latest
       - name: Run tests
-        run: pytest
+      # TODO: Restore form-runner tests once fork is running
+        run: pytest --ignore=tests/test_application_form.py
       - name: "Upload Accessibility Testing reports"
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The tests which use the form runner JSON are currently failing as we are not running our fork. Ignore these temporarily so we can un-block unrelated frontend changes from being merged.