### PR TITLE
FS-1163 add forms private host

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -51,7 +51,7 @@ jobs:
           cf_space: ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push -f manifest-dev.yml funding-service-design-frontend-dev
+          command: push -f manifest-dev.yml funding-service-design-frontend-dev --var FORMS_SERVICE_PRIVATE_HOST="${{secrets.FORMS_SERVICE_PRIVATE_HOST}}"
       - name: Run tests
         run: |
           python -m venv .venv
@@ -113,7 +113,7 @@ jobs:
           cf_space: ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push -f manifest-test.yml funding-service-design-frontend-test --var RSA256_PRIVATE_KEY_BASE64="${{secrets.RSA256_PRIVATE_KEY_BASE64}}" --var RSA256_PUBLIC_KEY_BASE64="${{secrets.RSA256_PUBLIC_KEY_BASE64}}"
+          command: push -f manifest-test.yml funding-service-design-frontend-test --var RSA256_PRIVATE_KEY_BASE64="${{secrets.RSA256_PRIVATE_KEY_BASE64}}" --var RSA256_PUBLIC_KEY_BASE64="${{secrets.RSA256_PUBLIC_KEY_BASE64}}" --var FORMS_SERVICE_PRIVATE_HOST="${{secrets.FORMS_SERVICE_PRIVATE_HOST}}"
       - name: Run tests
         env:
           # TODO: restore this to a custom domain once DNS is restored

--- a/app/models/helpers.py
+++ b/app/models/helpers.py
@@ -12,7 +12,11 @@ def get_token_to_return_to_application(form_name: str, rehydrate_payload):
         token_json = res.json()
         return token_json["token"]
     else:
-        return None
+        raise Exception(
+            "Unexpected response POSTing form token to"
+            f" {Config.FORM_GET_REHYDRATION_TOKEN_URL.format(form_name=form_name)},"  # noqa: E501
+            f" response code {res.status_code}"
+        )
 
 
 def extract_subset_of_data_from_application(
@@ -35,7 +39,9 @@ def extract_subset_of_data_from_application(
     return application_data[data_subset_name]
 
 
-def format_rehydrate_payload(micro_form_data, application_id, page_name, returnUrl):
+def format_rehydrate_payload(
+    micro_form_data, application_id, page_name, returnUrl
+):
     """
     Returns information in a JSON format that provides the
     POST body for the utilisation of the save and return
@@ -78,7 +84,7 @@ def format_rehydrate_payload(micro_form_data, application_id, page_name, returnU
         "callbackUrl": callback_url,
         "redirectPath": redirect_path,
         "customText": {"nextSteps": "Form Submitted"},
-        "returnUrl": returnUrl
+        "returnUrl": returnUrl,
     }
     formatted_data["questions"] = extract_subset_of_data_from_application(
         micro_form_data, "questions"

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -12,6 +12,7 @@ applications:
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-dev.london.cloudapps.digital
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-dev.apps.internal:8080
     FORMS_SERVICE_PUBLIC_HOST: https://forms.dev.gids.dev
+    FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))
     FLASK_ENV: dev
     FLASK_DEBUG: 1
   routes:

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -14,6 +14,7 @@ applications:
     FORMS_SERVICE_PUBLIC_HOST: https://forms.test.gids.dev
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     RSA256_PRIVATE_KEY_BASE64: ((RSA256_PRIVATE_KEY_BASE64))
+    FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))
     FLASK_ENV: test
   routes:
     - route: frontend.test.fundingservice.co.uk


### PR DESCRIPTION
On the new custom domain the form POST was failing as it was missing the credentials to communicate on the server-side, this uses the existing `FORMS_SERVICE_PRIVATE_HOST` config to provide the correct host.

Also adds better exception handling, as previous nothing was logged when this failed as the function returned `None`.