### PR TITLE
BAU: add missing config for fund store API host

### DIFF
--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -12,6 +12,7 @@ applications:
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-dev.london.cloudapps.digital
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-dev.apps.internal:8080
     FORMS_SERVICE_PUBLIC_HOST: https://forms.dev.gids.dev
+    FUND_STORE_API_HOST: https://funding-service-design-fund-store-dev.london.cloudapps.digital
     FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))
     FLASK_ENV: dev
     FLASK_DEBUG: 1

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -12,6 +12,7 @@ applications:
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-test.london.cloudapps.digital
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-test.apps.internal:8080
     FORMS_SERVICE_PUBLIC_HOST: https://forms.test.gids.dev
+    FUND_STORE_API_HOST: https://funding-service-design-fund-store-test.london.cloudapps.digital
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     RSA256_PRIVATE_KEY_BASE64: ((RSA256_PRIVATE_KEY_BASE64))
     FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))


### PR DESCRIPTION
Rendering the task list was failing on the deployed environments as the `FUND_STORE_API_HOST` was not configured, e.g.

```
   2022-08-15T09:48:36.03+0100 [APP/PROC/WEB/0] OUT {"name": "app.create_app", "levelname": "INFO", "message": "Fetching data from 'http://fund_store/funds/funding-service-design'.", "funcName": "get_data", "pathname": "/home/vcap/app/app/default/data.py", "lineno": 26, "instance_index": "0", "logType": "application"}
```