### PR TITLE
BAU: add missing default round ID and fund ID to config

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -133,3 +133,6 @@ class DefaultConfig:
     }
 
     USE_LOCAL_DATA = strtobool(getenv("USE_LOCAL_DATA", "False"))
+
+    DEFAULT_ROUND_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"
+    DEFAULT_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"


### PR DESCRIPTION
Without these set we can throw an exception when going to the dashboard e.g.
![Screenshot 2022-08-22 at 10 38 21](https://user-images.githubusercontent.com/1764158/185906272-a2aa7c64-a82a-47b3-9870-38557f435119.png)
 