### PR TITLE
BAU: fix fund casing

### DIFF
--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -11,7 +11,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l">{{ application_meta_data["fund_name"]}} {{ application_meta_data["round_name"] }}</span>
+            <span class="govuk-caption-l">{{ application_meta_data["fund_name"]}} {{ application_meta_data["round_name"]|lower }}</span>
             <h1 class="govuk-heading-xl">Application for funding to save an asset in your community</h1>
             <details class="govuk-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -11,7 +11,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l">{{ application_meta_data["fund_name"]|kebab_case_to_human }} {{ application_meta_data["round_name"] }}</span>
+            <span class="govuk-caption-l">{{ application_meta_data["fund_name"]}} {{ application_meta_data["round_name"] }}</span>
             <h1 class="govuk-heading-xl">Application for funding to save an asset in your community</h1>
             <details class="govuk-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">


### PR DESCRIPTION
Previously we were erroneously applying a filter on the already human readable fund name, which turned it to lower-case

## Before 
![Screenshot 2022-11-10 at 10 07 46](https://user-images.githubusercontent.com/1764158/201062585-2deb38b8-4e17-4172-b6cd-e8f0093baff6.png)

## After
![Screenshot 2022-11-10 at 10 09 26](https://user-images.githubusercontent.com/1764158/201062850-6d8fc196-ea96-489b-8aea-97187cb67a27.png)

