### PR TITLE
FS-1757: Add language availability notice

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -2,6 +2,7 @@
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% from "partials/start-application-button.html" import startApplicationButton %}
+{% from "partials/available_in_language.html" import available_in_language %}
 
 {% extends "base.html" %}
 {% block content %}
@@ -79,16 +80,7 @@
 
 {# TODO: restore this once Welsh translation is completed #}
 
-{#<p class="govuk-body">{% trans url=url_for('select_language', locale=('cy' if get_lang() == 'en' else 'en')) %} This service is also available <a href="{{ url }}" class="govuk-link">in Welsh (Cymraeg){% endtrans %}</a>.</p>#}
-{##}
-{#<div class="govuk-warning-text">#}
-{#    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>#}
-{#    <strong class="govuk-warning-text__text">#}
-{#      <span class="govuk-warning-text__assistive">Warning</span>#}
-{#      {% trans %}You cannot change the language of an existing application.{% endtrans %}#}
-{#    </strong>#}
-{#  </div>#}
-
+{{ available_in_language(inset=True, warn=True )}}
 
 {{startApplicationButton(form, url_for('routes.new'), applications=applications)}}
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -79,8 +79,7 @@
 
 
 {# TODO: restore this once Welsh translation is completed #}
-
-{{ available_in_language(inset=True, warn=True )}}
+{# available_in_language(inset=False, warn=True) #}
 
 {{startApplicationButton(form, url_for('routes.new'), applications=applications)}}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,7 +13,8 @@
                 <span class="govuk-caption-l">Community Ownership Fund</span>
             {% endif %}
             <h1 class="govuk-heading-xl">Start or continue an application for funding to save an asset in your community</h1>
-            {{ available_in_language(inset=True, warn=False) }}
+            {# TODO: restore this once Welsh translation is completed #}
+            {# available_in_language(inset=True, warn=False) #}
             <p class="govuk-body">You must have received an invitation to apply. If we did not invite you, first <a
                     class="govuk-link"
                     href="https://www.gov.uk/guidance/community-ownership-fund-round-2-how-to-express-your-interest-in-applying">express

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{% from "partials/available_in_language.html" import available_in_language %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -13,6 +13,7 @@
                 <span class="govuk-caption-l">Community Ownership Fund</span>
             {% endif %}
             <h1 class="govuk-heading-xl">Start or continue an application for funding to save an asset in your community</h1>
+            {{ available_in_language(inset=True, warn=False) }}
             <p class="govuk-body">You must have received an invitation to apply. If we did not invite you, first <a
                     class="govuk-link"
                     href="https://www.gov.uk/guidance/community-ownership-fund-round-2-how-to-express-your-interest-in-applying">express

--- a/app/templates/partials/available_in_language.html
+++ b/app/templates/partials/available_in_language.html
@@ -1,0 +1,13 @@
+{% macro available_in_language(inset, warn) %}
+<p class="govuk-body {{'govuk-inset-text' if inset else ''}}">{% trans url=url_for('select_language', locale=('cy' if get_lang() == 'en' else 'en')) %} This service is also available <a href="{{ url }}" class="govuk-link">in Welsh (Cymraeg){% endtrans %}</a>.</p>
+
+{% if warn %}
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      {% trans %}You cannot change the language of an existing application.{% endtrans %}
+    </strong>
+</div>
+{% endif %}
+{% endmacro %}


### PR DESCRIPTION
Extracted a macro for language availability component, add to dashboard & landing page.

Relevant prototypes:
https://fsd-funding-prototype-v2.herokuapp.com/s22-application/applicant-dashboard
https://fsd-funding-prototype-v2.herokuapp.com/s20-application/invite-page

Images:
https://user-images.githubusercontent.com/117724519/202692956-d0878580-5f09-4c03-933b-15ebbf8987f0.png
https://user-images.githubusercontent.com/117724519/202693022-7316718f-a7ab-4154-841c-24b75b969a86.png
