### PR TITLE
BAU: fix Welsh organisation form for unique tracker number page

### DIFF
--- a/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
+++ b/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
@@ -40,8 +40,8 @@
           "name": "WWWWxy",
           "options": { "classes": "govuk-!-width-full" },
           "type": "TextField",
-          "title": "\"Eich rhif traciwr unigryw\"",
-          "hint": "\"Roedd hwn wedi'i gynnwys yn y llythyr yr anfonom i gadarnhau eich datganiad o ddiddordeb llwyddiannus.\n\n<p>Er enghraifft, ‘ANON-###-###-###’ \"</p>",
+          "title": "Eich rhif traciwr unigryw",
+          "hint": "Roedd hwn wedi'i gynnwys yn y llythyr yr anfonom i gadarnhau eich datganiad o ddiddordeb llwyddiannus.\n\n<p>Er enghraifft, ‘ANON-###-###-###’</p>",
           "schema": {}
         },
         {


### PR DESCRIPTION
There were some extra speech marks being rendered on the page. This PR removes those.

Before
![image](https://user-images.githubusercontent.com/36962596/205685839-6cef696f-0ee2-473a-89cf-cae1711180fe.png)



After
