### PR TITLE
FS-2190: unique title tags

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -2,12 +2,12 @@
 
 {% from "partials/contact_details.html" import contact_details %}
 
-{% block pageTitle %}Page not found – {{ service_title }}{% endblock %}
+{% set pageHeading %}Page not found{% endset %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Page not found</h1>
+            <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <p class="govuk-body">If you typed the web address, check it is correct.</p>
             <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
             <p class="govuk-body">If the web address is correct or you selected a link or a button, contact

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block pageTitle %}Sorry, there is a problem with the service – {{ service_title }}{% endblock %}
+{% set pageHeading %}Sorry, there is a problem with the service{% endset %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+            <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <p class="govuk-body">Try again later.</p>
             <p class="govuk-body"><a class="govuk-link" href="/contact_us">Contact the Community Ownership Fund</a> if you have any questions.</p>
         </div>

--- a/app/templates/accessibility_statement.html
+++ b/app/templates/accessibility_statement.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-
+{% set pageHeading %}Accessibility statement{% endset %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Accessibility statement</h1>
+            <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <p class="govuk-body">The Department of Levelling Up, Housing and Communities is committed to making our online services accessible to all users by meeting <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps" class="govuk-link">The Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</a>. We have commissioned <a href="https://digitalaccessibilitycentre.org" class="govuk-link">The Digital Accessibility Centre (DAC)</a> to carry out an accessibility audit of our services. This will include:</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li><a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web content accessibility guidelines (WCAG) 2.1</a> AA level technical compliance audits</li>

--- a/app/templates/application_submitted.html
+++ b/app/templates/application_submitted.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %} {% from "govuk_frontend_jinja/components/button/macro.html"
 import govukButton -%}
+{% set pageHeading %}Application complete{% endset %}
 {% block content %}
 
   <div class="govuk-width-container">
@@ -8,7 +9,7 @@ import govukButton -%}
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-panel govuk-panel--confirmation">
             <h1 class="govuk-panel__title">
-              Application complete
+              {{pageHeading}}
             </h1>
             <div class="govuk-panel__body">
               Your reference number<br><strong>{{application_reference}}</strong>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,7 +2,9 @@
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
-{% block pageTitle %}{{ service_title }}{% endblock %}
+
+
+{% block pageTitle %} {{ [pageHeading, service_title]|join(' - ') if pageHeading else service_title }} {% endblock %}
 
 {% block head %}
   {% include 'head.html' %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,7 @@
 
 
 
-{% block pageTitle %} {{ [pageHeading, service_title]|join(' - ') if pageHeading else service_title }} {% endblock %}
+{% block pageTitle %}{{[pageHeading, service_title]|join(' - ') if pageHeading else service_title}}{% endblock %}
 
 {% block head %}
   {% include 'head.html' %}

--- a/app/templates/cof_r2w2_all_questions.html
+++ b/app/templates/cof_r2w2_all_questions.html
@@ -3,12 +3,12 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 {% from "partials/file-formats.html" import file_formats %}
-
+{% set pageHeading %}{% trans %}Full list of application questions{% endtrans %}{% endset %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{% trans %}Community Ownership Fund Round 2 Window 2{% endtrans %}</span>
-            <h1 class="govuk-heading-xl">{% trans %}Full list of application questions{% endtrans %}</h1>
+            <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <div class="govuk-!-margin-bottom-8">
                 <h2 class="govuk-heading-m ">{% trans %}Table of contents{% endtrans %}</h2>
                 <ol class="govuk-list govuk-list--number">

--- a/app/templates/contact_us.html
+++ b/app/templates/contact_us.html
@@ -3,11 +3,11 @@
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {% from "partials/contact_details.html" import contact_details %}
-
+{% set pageHeading %}Contact us{% endset %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Contact us</h1>
+            <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <p class="govuk-body">Contact the Community Ownership Fund if you have any questions. </p>
             {% if round_data.contact_details["email_address"]|length %}
                 {{ contact_details(

--- a/app/templates/cookie_policy.html
+++ b/app/templates/cookie_policy.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
+{% set pageHeading %}Cookies{% endset %}
 {% block content %}
     <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Cookies</h1>
+    <h1 class="govuk-heading-l">{{pageHeading}}</h1>
     <p class="govuk-body">
         Cookies are small files saved on your phone, tablet or computer when you visit a website.
     </p>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -6,8 +6,11 @@
 {% from "partials/round_closed_warning.html" import round_closed_warning %}
 
 {% extends "base.html" %}
+{% set pageHeading %}
+{% trans %}Your applications{% endtrans %}
+{% endset %}
 {% block content %}
-    <h1 class="govuk-heading-xl">{% trans %}Your applications{% endtrans %}</h1>
+    <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
 {% if is_past_submission_deadline %}
     {{ round_closed_warning(fund_name, round_title, submission_deadline) }}
 {% endif %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,4 +1,6 @@
-{% extends "base.html" %} {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText
+{% set pageHeading = 'Start or continue an application for funding to save an asset in your community' %}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText
     -%} {%- from "govuk_frontend_jinja/components/button/macro.html" import
     govukButton -%} {% from "partials/available_in_language.html" import available_in_language %} {% from "partials/round_closed_warning.html" import round_closed_warning %}
  {% block content %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,7 @@
-{% set pageHeading = 'Start or continue an application for funding to save an asset in your community' %}
 {% extends "base.html" %}
+{% set pageHeading %}
+{% trans %}Start or continue an application for funding to save an asset in your community{% endtrans %}
+{% endset %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText
     -%} {%- from "govuk_frontend_jinja/components/button/macro.html" import
     govukButton -%} {% from "partials/available_in_language.html" import available_in_language %} {% from "partials/round_closed_warning.html" import round_closed_warning %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,7 +14,7 @@
             <span class="govuk-caption-l">{{fund_name}}</span>
             {% endif %}
             <h1 class="govuk-heading-xl">
-                {% trans %}Start or continue an application for funding to save an asset in your community{% endtrans %}
+                {{pageHeading}}
             </h1>
             {% if is_past_submission_deadline %}
                 {{ round_closed_warning(fund_name, round_title, submission_deadline) }}

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -6,7 +6,7 @@
 {% block beforeContent %}
     <a href="{{ url_for('account_routes.dashboard') }}" class="govuk-back-link">Back to your applications</a>
 {% endblock %}
-{% block pageTitle %}{% trans %}Task List{% endtrans %} - {{ service_title }}{% endblock %}
+{% set pageHeading %}{% trans %}Task List{% endtrans %}{% endset %}
 
 {% block content %}
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -r requirements.txt
 bandit
+beautifulsoup4
 dparse>=0.5.2
 black
 deepdiff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,8 @@ babel==2.10.3
     #   flask-babel
 bandit==1.7.4
     # via -r requirements-dev.in
+beautifulsoup4==4.11.1
+    # via -r requirements-dev.in
 black==22.6.0
     # via -r requirements-dev.in
 blinker==1.5
@@ -288,6 +290,8 @@ sniffio==1.2.0
     # via trio
 sortedcontainers==2.4.0
     # via trio
+soupsieve==2.3.2.post1
+    # via beautifulsoup4
 stevedore==3.5.0
     # via bandit
 tenacity==6.3.1

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,6 +2,7 @@
 Tests the routes and their contents using the dict within
 "route_testing_conf.py".
 """
+from bs4 import BeautifulSoup
 from tests.route_testing_conf import routes_and_test_content
 
 
@@ -20,7 +21,9 @@ def test_routes_status_code(flask_test_client, monkeypatch, mocker):
     )
     for route, _ in routes_and_test_content.items():
         response = flask_test_client.get(route, follow_redirects=True)
-        assert 200 == response.status_code, f"Incorrect status code returned for route {route}"
+        assert (
+            200 == response.status_code
+        ), f"Incorrect status code returned for route {route}"
 
 
 def test_routes_content(flask_test_client, monkeypatch):
@@ -54,3 +57,14 @@ def test_dodgy_url_returns_404(flask_test_client):
     """
     response = flask_test_client.get("/rubbish", follow_redirects=True)
     assert response.status_code == 404
+
+
+def test_page_title_includes_heading(flask_test_client):
+    response = flask_test_client.get("/", follow_redirects=True)
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert (
+        soup.title.string
+        == "Start or continue an application for funding to save an asset in"
+        " your community - Apply for funding to save an asset in your"
+        " community"
+    )


### PR DESCRIPTION
As highlighted in the accessibility audit, pages should have unique titles, previously most pages just used the `service_title`

This adds a `pageHeading` variable in the base template which is used in the <title> tag if set and as the `h1` to avoid duplication and encourage re-use of this pattern in future. 