### PR TITLE
FS-2194: Group form controls

### DIFF
--- a/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
+++ b/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
@@ -96,13 +96,21 @@
           "schema": {}
         },
         {
+          "name": "XFvKwZ",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"XFvKwZ\"><legend class=\"govuk-label govuk-label--s\">Enwau amgen eich sefydliad</legend>",
+          "schema": {}
+        },
+        {
           "name": "PHFkCs",
           "options": {
-            "classes": "govuk-!-width-full"
+            "classes": "govuk-!-width-full",
+            "hideTitle": true
           },
           "type": "TextField",
           "title": "Enwau amgen eich sefydliad",
-          "hint": "<span class=\"govuk-body\">Enw amgen 1</span>",
+          "hint": "<label for=\"PHFkCs\" class=\"govuk-body\">Enw amgen 1</label>",
           "schema": {}
         },
         {
@@ -114,7 +122,7 @@
           },
           "type": "TextField",
           "title": "Enwau amgen eich sefydliad - Enw amgen 2 ",
-          "hint": "<span class=\"govuk-body\">Enw amgen 2 (dewisol)</span>",
+          "hint": "<label for=\"QgNhXX\"  class=\"govuk-body\">Enw amgen 2 (dewisol)</label>",
           "schema": {}
         },
         {
@@ -126,7 +134,14 @@
           },
           "type": "TextField",
           "title": " Enwau amgen eich sefydliad - Enw amgen 3 ",
-          "hint": "<span class=\"govuk-body\">Enw amgen 3 (dewisol)</span>",
+          "hint": "<label for=\"XCcqae\" class=\"govuk-body\">Enw amgen 3 (dewisol)</label>",
+          "schema": {}
+        },
+        {
+          "name": "yiAMdU",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],
@@ -157,6 +172,13 @@
           "schema": {}
         },
         {
+          "name": "tgnZof",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"tgnZof\"><legend class=\"govuk-label govuk-label--s\">Dywedwch wrthym am brif weithgareddau eich sefydliad</legend>",
+          "schema": {}
+        },
+        {
           "name": "btTtIb",
           "options": {
             "maxWords": "500",
@@ -164,7 +186,7 @@
           },
           "type": "MultilineTextField",
           "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Dywedwch wrthym am brif weithgareddau eich sefydliad</span><span class=\"govuk-body\">Gweithgarwch 1</span>",
+          "hint": "<label for=\"btTtIb\" class=\"govuk-body\">Gweithgarwch 1</label>",
           "schema": {}
         },
         {
@@ -177,7 +199,7 @@
           },
           "type": "MultilineTextField",
           "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad - Gweithgarwch 2",
-          "hint": "<span class=\"govuk-body\">Gweithgarwch 2 (dewisol)</span>",
+          "hint": "<label for=\"SkocDi\" class=\"govuk-body\">Gweithgarwch 2 (dewisol)</label>",
           "schema": {}
         },
         {
@@ -189,7 +211,14 @@
           },
           "type": "MultilineTextField",
           "title": "Dywedwch wrthym am brif weithgareddau eich sefydliad - Gweithgarwch 3",
-          "hint": "<span class=\"govuk-body\">Gweithgarwch 3 (dewisol)</span>",
+          "hint": "<label for=\"CNeeiC\" class=\"govuk-body\">Gweithgarwch 3 (dewisol)</label>",
+          "schema": {}
+        },
+        {
+          "name": "DhpcVW",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         },
         {
@@ -226,6 +255,13 @@
           "schema": {}
         },
         {
+          "name": "SXfYwl",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"SXfYwl\"><legend class=\"govuk-label govuk-label--s\">Disgrifiwch eich prosiectau blaenorol</legend>",
+          "schema": {}
+        },
+        {
           "name": "wxCszQ",
           "options": {
             "maxWords": "500",
@@ -233,7 +269,7 @@
           },
           "type": "MultilineTextField",
           "title": "Disgrifiwch eich prosiectau blaenorol",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Disgrifiwch eich prosiectau blaenorol</span><span class=\"govuk-body\">Prosiect 1</span>",
+          "hint": "<label for=\"wxCszQ\" class=\"govuk-body\">Prosiect 1</label>",
           "schema": {}
         },
         {
@@ -245,7 +281,7 @@
           },
           "type": "MultilineTextField",
           "title": "Disgrifiwch eich prosiectau blaenorol - Prosiect 2",
-          "hint": "<span class=\"govuk-body\">Prosiect 2 (dewisol)</span>",
+          "hint": "<label for=\"QJFQgi\" class=\"govuk-body\">Prosiect 2 (dewisol)</label>",
           "schema": {}
         },
         {
@@ -257,7 +293,14 @@
           },
           "type": "MultilineTextField",
           "title": "Disgrifiwch eich prosiectau blaenorol - Prosiect 3",
-          "hint": "<span class=\"govuk-body\">Prosiect 3 (dewisol)</span>",
+          "hint": "<label for=\"DGNWqE\" class=\"govuk-body\">Prosiect 3 (dewisol)</label>",
+          "schema": {}
+        },
+        {
+          "name": "lsKMnV",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],
@@ -491,6 +534,13 @@
           }
         },
         {
+          "name": "zyWOmY",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Gwefan a chyfryngau cymdeithasol<span class=\"govuk-body\">Er enghraifft, cyfrifon Facebook, Instagram neu Twitter eich cwmni (os yw'n gymwys)</span></legend></br>",
+          "schema": {}
+        },
+        {
           "name": "FhbaEy",
           "options": {
             "classes": "govuk-!-width-full",
@@ -498,7 +548,7 @@
           },
           "type": "WebsiteField",
           "title": "Gwefan a chyfryngau cymdeithasol",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Website and social media</span><span class=\"govuk-body\">Er enghraifft, cyfrifon Facebook, Instagram neu Twitter eich cwmni (os yw'n gymwys)</span><br><br><span class=\"govuk-body\">Dolen 1</span>\n",
+          "hint": "<label for=\"FhbaEy\" class=\"govuk-body\">Dolen 1</label>\n",
           "schema": {}
         },
         {
@@ -510,7 +560,7 @@
           },
           "type": "WebsiteField",
           "title": "Gwefan a chyfryngau cymdeithasol - Dolen 2",
-          "hint": "<span class=\"govuk-body\">Dolen 2 (dewisol)</span>",
+          "hint": "<label for=\"FcdKlB\" class=\"govuk-body\">Dolen 2 (dewisol)</label>",
           "schema": {}
         },
         {
@@ -522,7 +572,14 @@
           },
           "type": "WebsiteField",
           "title": "Gwefan a chyfryngau cymdeithasol - Dolen 3",
-          "hint": "<span class=\"govuk-body\">Dolen 3 (dewisol)</span>",
+          "hint": "<label for=\"BzxgDA\" class=\"govuk-body\">Dolen 3 (dewisol)</label>",
+          "schema": {}
+        },
+        {
+          "name": "vuutkz",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],

--- a/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
+++ b/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
@@ -537,7 +537,7 @@
           "name": "zyWOmY",
           "options": {},
           "type": "Html",
-          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Gwefan a chyfryngau cymdeithasol<span class=\"govuk-body\">Er enghraifft, cyfrifon Facebook, Instagram neu Twitter eich cwmni (os yw'n gymwys)</span></legend></br>",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Gwefan a chyfryngau cymdeithasol<span class=\"govuk-body\"></br>Er enghraifft, cyfrifon Facebook, Instagram neu Twitter eich cwmni (os yw'n gymwys)</span></legend></br>",
           "schema": {}
         },
         {

--- a/form_jsons/public/en/organisation-information.json
+++ b/form_jsons/public/en/organisation-information.json
@@ -523,7 +523,7 @@
           "name": "zyWOmY",
           "options": {},
           "type": "Html",
-          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Website and social media<span class=\"govuk-body\">For example, your company's Facebook, Instagram or Twitter accounts (if applicable)</span></legend></br>",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Website and social media<span class=\"govuk-body\"></br>For example, your company's Facebook, Instagram or Twitter accounts (if applicable)</span></legend></br>",
           "schema": {}
         },
         {

--- a/form_jsons/public/en/organisation-information.json
+++ b/form_jsons/public/en/organisation-information.json
@@ -91,13 +91,21 @@
           "schema": {}
         },
         {
+          "name": "XFvKwZ",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"XFvKwZ\"><legend class=\"govuk-label govuk-label--s\">Alternative names of your organisation</legend>",
+          "schema": {}
+        },
+        {
           "name": "PHFkCs",
           "options": {
-            "classes": "govuk-!-width-full"
+            "classes": "govuk-!-width-full",
+            "hideTitle": true
           },
           "type": "TextField",
           "title": "Alternative names of your organisation",
-          "hint": "<span class=\"govuk-body\">Alternative name 1</span>",
+          "hint": "<label for=\"PHFkCs\" class=\"govuk-body\">Alternative name 1</label>",
           "schema": {}
         },
         {
@@ -109,7 +117,7 @@
           },
           "type": "TextField",
           "title": "Alternative names of your organisation - Alternative name 2 ",
-          "hint": "<span class=\"govuk-body\">Alternative name 2 (optional)</span>",
+          "hint": "<label for=\"QgNhXX\" class=\"govuk-body\">Alternative name 2 (optional)</label>",
           "schema": {}
         },
         {
@@ -121,7 +129,14 @@
           },
           "type": "TextField",
           "title": "Alternative names of your organisation - Alternative name 3 ",
-          "hint": "<span class=\"govuk-body\">Alternative name 3 (optional)</span>",
+          "hint": "<label for=\"XCcqae\" class=\"govuk-body\">Alternative name 3 (optional)</label>",
+          "schema": {}
+        },
+        {
+          "name": "yiAMdU",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],
@@ -152,6 +167,13 @@
           "schema": {}
         },
         {
+          "name": "tgnZof",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"tgnZof\"><legend class=\"govuk-label govuk-label--s\">Tell us about your organisation's main activities</legend>",
+          "schema": {}
+        },
+        {
           "name": "btTtIb",
           "options": {
             "maxWords": "500",
@@ -159,7 +181,7 @@
           },
           "type": "MultilineTextField",
           "title": "Tell us about your organisation's main activities",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Tell us about your organisation's main activities</span><span class=\"govuk-body\">Activity 1</span>",
+          "hint": "<label for=\"btTtIb\" class=\"govuk-body\">Activity 1</label>",
           "schema": {}
         },
         {
@@ -172,7 +194,7 @@
           },
           "type": "MultilineTextField",
           "title": "Tell us about your organisation's main activities - Activity 2 ",
-          "hint": "<span class=\"govuk-body\">Activity 2 (optional)</span>",
+          "hint": "<label for=\"SkocDi\" class=\"govuk-body\">Activity 2 (optional)</label>",
           "schema": {}
         },
         {
@@ -184,7 +206,14 @@
           },
           "type": "MultilineTextField",
           "title": "Tell us about your organisation's main activities - Activity 3 ",
-          "hint": "<span class=\"govuk-body\">Activity 3 (optional)</span>",
+          "hint": "<label for=\"CNeeiC\" class=\"govuk-body\">Activity 3 (optional)</label>",
+          "schema": {}
+        },
+        {
+          "name": "DhpcVW",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         },
         {
@@ -218,6 +247,13 @@
           "schema": {}
         },
         {
+          "name": "SXfYwl",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"SXfYwl\"><legend class=\"govuk-label govuk-label--s\">Describe your previous projects</legend>",
+          "schema": {}
+        },
+        {
           "name": "wxCszQ",
           "options": {
             "maxWords": "500",
@@ -225,7 +261,7 @@
           },
           "type": "MultilineTextField",
           "title": "Describe your previous projects",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Describe your previous projects</span><span class=\"govuk-body\">Project 1</span>",
+          "hint": "<label for=\"wxCszQ\" class=\"govuk-body\">Project 1</label>",
           "schema": {}
         },
         {
@@ -237,7 +273,7 @@
           },
           "type": "MultilineTextField",
           "title": "Describe your previous projects - Project 2 ",
-          "hint": "<span class=\"govuk-body\">Project 2 (optional)</span>",
+          "hint": "<label for=\"QJFQgi\" class=\"govuk-body\">Project 2 (optional)</label>",
           "schema": {}
         },
         {
@@ -249,7 +285,14 @@
           },
           "type": "MultilineTextField",
           "title": "Describe your previous projects - Project 3 ",
-          "hint": "<span class=\"govuk-body\">Project 3 (optional)</span>",
+          "hint": "<label for=\"DGNWqE\" class=\"govuk-body\">Project 3 (optional)</label>",
+          "schema": {}
+        },
+        {
+          "name": "lsKMnV",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],
@@ -477,6 +520,13 @@
           "schema": {}
         },
         {
+          "name": "zyWOmY",
+          "options": {},
+          "type": "Html",
+          "content": "<fieldset class=\"govuk-fieldset\" id=\"zyWOmY\"><legend class=\"govuk-label govuk-label--s\">Website and social media<span class=\"govuk-body\">For example, your company's Facebook, Instagram or Twitter accounts (if applicable)</span></legend></br>",
+          "schema": {}
+        },
+        {
           "name": "FhbaEy",
           "options": {
             "classes": "govuk-!-width-full",
@@ -484,7 +534,7 @@
           },
           "type": "WebsiteField",
           "title": "Website and social media",
-          "hint": "<span class=\"govuk-label govuk-label--s\">Website and social media</span><span class=\"govuk-body\">For example, your company's Facebook, Instagram or Twitter accounts (if applicable)</span><br><br><span class=\"govuk-body\">Link 1</span>\n",
+          "hint": "<label for=\"FhbaEy\" class=\"govuk-body\">Link 1</label>\n",
           "schema": {}
         },
         {
@@ -496,7 +546,7 @@
           },
           "type": "WebsiteField",
           "title": "Website and social media - Link or username 2",
-          "hint": "<span class=\"govuk-body\">Link 2 (optional)</span>",
+          "hint": "<label for=\"FcdKlB\" class=\"govuk-body\">Link 2 (optional)</label>",
           "schema": {}
         },
         {
@@ -508,7 +558,14 @@
           },
           "type": "WebsiteField",
           "title": "Website and social media - Link or username 3",
-          "hint": "<span class=\"govuk-body\">Link 3 (optional)</span>",
+          "hint": "<label for=\"BzxgDA\" class=\"govuk-body\">Link 3 (optional)</label>",
+          "schema": {}
+        },
+        {
+          "name": "vuutkz",
+          "options": {},
+          "type": "Html",
+          "content": "</fieldset>",
           "schema": {}
         }
       ],


### PR DESCRIPTION
On pages 30-34 of the accessibility audit report - a few specific instances are mentioned where there were many inputs that were relevant to one another, but were not grouped appropriately in a fieldset, this caused confusion for screen readers as they weren't informed of the relation between the inputs automatically, and had to snoop around to get an understanding of the grouping and relation.

This change encloses related optional fields in a `<fieldset>`, and changes any enclosed hints to corresponding a `<label>`, meaning screen readers will detect the grouping and relation of the inputs automatically, and announce the correct label/information for the user.

Note that this has been change for both English/Welsh forms.