### PR TITLE
Fs 2235 fix duplicated page headings

### DIFF
--- a/form_jsons/public/en/applicant-information.json
+++ b/form_jsons/public/en/applicant-information.json
@@ -11,7 +11,7 @@
           "name": "ZAKTgH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Applicant information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Lead contact details</h2>"
         },
         {
           "name": "ZBjDTn",

--- a/form_jsons/public/en/asset-information.json
+++ b/form_jsons/public/en/asset-information.json
@@ -11,7 +11,7 @@
           "name": "pkTHJq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How the asset is used in the community</h2>"
         },
         {
           "name": "yaQoxU",
@@ -40,7 +40,7 @@
           "name": "LjSaeq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How the asset is used in the community</h2>"
         },
         {
           "name": "GjzaqR",
@@ -63,7 +63,7 @@
           "name": "nouxzF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How you’ll own or lease the asset</h2>"
         },
         {
           "name": "VWkLlk",
@@ -98,7 +98,7 @@
           "name": "Fmluly",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Who currently owns the asset</h2>"
         },
         {
           "name": "ymlmrX",
@@ -123,7 +123,7 @@
           "name": "bLCDBI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If you’ve already taken ownership</h2>"
         },
         {
           "name": "gkulUE",
@@ -154,7 +154,7 @@
           "name": "fJVdgL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Current ownership status</h2>"
         },
         {
           "name": "FtDJfK",
@@ -179,7 +179,7 @@
           "name": "lusfLU",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Terms of your ownership or lease</h2>"
         },
         {
           "name": "uBXptf",
@@ -205,7 +205,7 @@
           "name": "MRrIQO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Expected terms of your ownership or lease</h2>"
         },
         {
           "name": "nvMmGE",
@@ -238,7 +238,7 @@
           "name": "gaXSIn",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Public ownership</h2>"
         },
         {
           "name": "Wyesgy",
@@ -265,7 +265,7 @@
           "name": "PoZmwV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Public ownership details and declarations</h2>"
         },
         {
           "name": "fHvilU",
@@ -335,7 +335,7 @@
           "name": "ZyEFDq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Assets of Community Value</h2>"
         },
         {
           "name": "hvzzWB",
@@ -365,7 +365,7 @@
           "name": "cQpClK",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Purchasing within the timeframe</h2>"
         },
         {
           "name": "MLwpjP",
@@ -391,7 +391,7 @@
           "name": "iZzvMF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Assets listed for disposal</h2>"
         },
         {
           "name": "VwxiGn",
@@ -418,7 +418,7 @@
           "name": "LfCMtg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Asset listing details</h2>"
         },
         {
           "name": "bkbGIE",
@@ -458,7 +458,7 @@
           "name": "ZCNFUF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Asset information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Risk of closure</h2>"
         },
         {
           "name": "UDTxqC",

--- a/form_jsons/public/en/community-benefits.json
+++ b/form_jsons/public/en/community-benefits.json
@@ -11,7 +11,7 @@
           "name": "UiHVet",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community benefits</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How the asset will benefit the community under your ownership</h2>"
         },
         {
           "name": "QjJtbs",

--- a/form_jsons/public/en/community-engagement.json
+++ b/form_jsons/public/en/community-engagement.json
@@ -11,7 +11,7 @@
           "name": "Skuupp",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community engagement</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How you’ve engaged with the community about the asset</h2>"
         },
         {
           "name": "HJBgvw",
@@ -39,7 +39,7 @@
           "name": "mCOxVf",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community engagement</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your project and wider plans</h2>"
         },
         {
           "name": "NZKHOp",
@@ -65,7 +65,7 @@
           "name": "EjFSzg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community engagement</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your fundraising activities</h2>"
         },
         {
           "name": "dpLyQh",

--- a/form_jsons/public/en/community-representation.json
+++ b/form_jsons/public/en/community-representation.json
@@ -11,7 +11,7 @@
           "name": "GHjwwB",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community representation</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How you’ll run the asset</h2>"
         },
         {
           "name": "JnvsPq",

--- a/form_jsons/public/en/community-use.json
+++ b/form_jsons/public/en/community-use.json
@@ -11,7 +11,7 @@
           "name": "AwAAQG",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Community use</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Who uses and benefits from the asset</h2>"
         },
         {
           "name": "CDwTrG",

--- a/form_jsons/public/en/declarations.json
+++ b/form_jsons/public/en/declarations.json
@@ -11,7 +11,7 @@
           "name": "sBiSgs",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Final confirmations</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Application declarations</h2>"
         },
         {
           "name": "LlvhYl",

--- a/form_jsons/public/en/environmental-sustainability.json
+++ b/form_jsons/public/en/environmental-sustainability.json
@@ -11,7 +11,7 @@
           "name": "WnykzV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Environmental sustainability</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How you’ve considered the environment</h2>"
         },
         {
           "name": "CvVZJv",

--- a/form_jsons/public/en/feasibility.json
+++ b/form_jsons/public/en/feasibility.json
@@ -11,7 +11,7 @@
           "name": "VjoSon",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Feasibility</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Feasibility studies you’ve carried out</h2>"
         },
         {
           "name": "FIKWHB",

--- a/form_jsons/public/en/funding-required.json
+++ b/form_jsons/public/en/funding-required.json
@@ -22,7 +22,7 @@
           "name": "uKmWaC",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Capital funding for your project</h2>"
         },
         {
           "name": "FhOGcz",
@@ -72,7 +72,7 @@
           "name": "eJdudr",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Revenue funding for your project</h2>"
         },
         {
           "name": "PZANlN",
@@ -124,7 +124,7 @@
           "name": "ZLsNnZ",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Secured match funding for your project</h2>"
         },
         {
           "name": "rgGQHh",
@@ -162,7 +162,7 @@
           "name": "PtVfWP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If you’ve secured match funding</h2>"
         },
         {
           "name": "DIZZOC",
@@ -184,7 +184,7 @@
           "name": "smwSHp",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Valuation of the asset</h2>"
         },
         {
           "name": "cGVEui",
@@ -238,7 +238,7 @@
           "name": "sXyxUW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If you’re requesting revenue funding</h2>"
         },
         {
           "name": "NWTKzQ",
@@ -262,7 +262,7 @@
           "name": "NcZEsI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If you’ve identified further match funding</h2>"
         },
         {
           "name": "RvbwSX",
@@ -297,7 +297,7 @@
           "name": "oHcGUy",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Identified match funding for your project</h2>"
         },
         {
           "name": "RafXFy",
@@ -335,7 +335,7 @@
           "name": "VfUORj",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Funding required</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Total funding request from the Community Ownership Fund</h2>"
         },
         {
           "name": "XcjQVp",

--- a/form_jsons/public/en/inclusiveness-and-integration.json
+++ b/form_jsons/public/en/inclusiveness-and-integration.json
@@ -11,7 +11,7 @@
           "name": "XWvsQw",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Inclusiveness and integration</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How you’ll make the asset inclusive</h2>"
         },
         {
           "name": "SrtVAs",

--- a/form_jsons/public/en/local-support.json
+++ b/form_jsons/public/en/local-support.json
@@ -11,7 +11,7 @@
           "name": "tztfSa",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Local support</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your support for the project</h2>"
         },
         {
           "name": "KqoaJL",
@@ -42,7 +42,7 @@
           "name": "abqMko",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Local support</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Local support details</h2>"
         },
         {
           "name": "BFbzux",

--- a/form_jsons/public/en/organisation-information.json
+++ b/form_jsons/public/en/organisation-information.json
@@ -37,7 +37,7 @@
           "name": "uNgkim",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Organisation names</h2>",
           "schema": {}
         },
         {
@@ -87,7 +87,7 @@
           "name": "wnoFHW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Organisation names</h2>",
           "schema": {}
         },
         {
@@ -139,7 +139,7 @@
           "name": "KYKyud",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Purpose and activities</h2>",
           "schema": {}
         },
         {
@@ -214,7 +214,7 @@
           "name": "QuTAqW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Previous projects similar to this one </h2>",
           "schema": {}
         },
         {
@@ -267,7 +267,7 @@
           "name": "pTuytP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">How your organisation is classified</h2>",
           "schema": {}
         },
         {
@@ -306,7 +306,7 @@
           "name": "QzkrIE",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">How your organisation is classified</h2>",
           "schema": {}
         },
         {
@@ -333,7 +333,7 @@
           "name": "toyZsH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Registration details</h2>",
           "schema": {}
         },
         {
@@ -367,7 +367,7 @@
           "name": "rHMVcR",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Charity registration details</h2>",
           "schema": {}
         },
         {
@@ -394,7 +394,7 @@
           "name": "MgmuIz",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Trading subsidiaries</h2>",
           "schema": {}
         },
         {
@@ -424,7 +424,7 @@
           "name": "UNQlIu",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Parent organisation details</h2>",
           "schema": {}
         },
         {
@@ -459,7 +459,7 @@
           "name": "vRPbaz",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Address and social media accounts</h2>",
           "schema": {}
         },
         {
@@ -531,7 +531,7 @@
           "name": "WYZWDE",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Correspondence address</h2>",
           "schema": {}
         },
         {
@@ -556,7 +556,7 @@
           "name": "OKCdpZ",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Joint applications</h2>",
           "schema": {}
         },
         {
@@ -589,7 +589,7 @@
           "name": "YnSQGx",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Partner organisation details</h2>",
           "schema": {}
         },
         {
@@ -641,7 +641,7 @@
           "name": "TUqPvI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Company registration details</h2>",
           "schema": {}
         },
         {
@@ -668,7 +668,7 @@
           "name": "nITyAP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Organisation information</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Registration details</h2>",
           "schema": {}
         },
         {

--- a/form_jsons/public/en/project-costs.json
+++ b/form_jsons/public/en/project-costs.json
@@ -11,7 +11,7 @@
           "name": "OdTNhg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project costs</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cashflow to run the asset</h2>"
         },
         {
           "name": "URmfYy",
@@ -55,7 +55,7 @@
           "name": "FHZRAe",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project costs</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Income to run the asset</h2>"
         },
         {
           "name": "fzAoYw",
@@ -105,7 +105,7 @@
           "name": "MSEqcL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project costs</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Running costs of the asset</h2>"
         },
         {
           "name": "lIusUr",

--- a/form_jsons/public/en/project-information.json
+++ b/form_jsons/public/en/project-information.json
@@ -35,7 +35,7 @@
           "name": "aVhByI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Previous Community Ownership Fund funding</h2>"
         },
         {
           "name": "gScdbf",
@@ -62,7 +62,7 @@
           "name": "tmVEPV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Projects previously funded by the Community Ownership Fund</h2>"
         },
         {
           "name": "IrIYcA",
@@ -95,7 +95,7 @@
           "name": "umDxBP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Project name and summary</h2>"
         },
         {
           "name": "KAgrBz",
@@ -145,7 +145,7 @@
           "name": "tpQVaN",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project information</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Address of the asset</h2>"
         },
         {
           "name": "yEmHpp",

--- a/form_jsons/public/en/project-qualification.json
+++ b/form_jsons/public/en/project-qualification.json
@@ -11,7 +11,7 @@
           "name": "jsBTOY",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project qualification</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If your project meets the definition</h2>"
         },
         {
           "name": "HvxXPI",
@@ -43,7 +43,7 @@
           "name": "IoCBIO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project qualification</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How your project will comply with the regulations</h2>"
         },
         {
           "name": "RmMKzM",
@@ -88,7 +88,7 @@
           "name": "tYvkAL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Project qualification</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">How your project will comply with state aid rules</h2>"
         },
         {
           "name": "xPkdRX",

--- a/form_jsons/public/en/risk.json
+++ b/form_jsons/public/en/risk.json
@@ -11,7 +11,7 @@
           "name": "nDfjRY",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Risk</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your project risk register</h2>"
         },
         {
           "name": "LVXUhZ",

--- a/form_jsons/public/en/skills-and-resources.json
+++ b/form_jsons/public/en/skills-and-resources.json
@@ -11,7 +11,7 @@
           "name": "jdiAQM",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Skills and resources</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">If you have experience running similar assets</h2>"
         },
         {
           "name": "eenpQC",
@@ -45,7 +45,7 @@
           "name": "KVYefk",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Skills and resources</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Recruitment plans</h2>"
         },
         {
           "name": "uMhZAI",
@@ -86,7 +86,7 @@
           "name": "SUVlQH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Skills and resources</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your experience running similar assets</h2>"
         },
         {
           "name": "pepEsp",
@@ -118,7 +118,7 @@
           "name": "OtWwRe",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Skills and resources</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Roles you’ll recruit to help you run the asset</h2>"
         },
         {
           "name": "mxgewf",

--- a/form_jsons/public/en/upload-business-plan.json
+++ b/form_jsons/public/en/upload-business-plan.json
@@ -38,7 +38,7 @@
           "name": "QAgOjR",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Business plan</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Your business plan</h2>"
         },
         {
           "name": "qZNAHj",

--- a/form_jsons/public/en/value-to-the-community.json
+++ b/form_jsons/public/en/value-to-the-community.json
@@ -11,7 +11,7 @@
           "name": "zbEFpO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Value to the community</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">About the wider community</h2>"
         },
         {
           "name": "oOPUXI",


### PR DESCRIPTION
 Accessibility Report (Pages 15-16) states there are page titles (h2's) which are duplicated within forms. 

This ticket addresses this by making h2 titles unique within each form.

Jira ticket: https://digital.dclg.gov.uk/jira/secure/RapidBoard.jspa?rapidView=110&projectKey=FS&view=detail&selectedIssue=FS-2235#:~:text=Funding%20Service%20Design-,FS%2D2235,-Close%20detail%20(%20T
