### PR TITLE
BAU: All questions round 2 window 3 page

### DIFF
--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -182,8 +182,9 @@ def tasklist(application_id):
             ),
             all_questions_url=url_for(
                 "content_routes.all_questions",
-                fund_id=fund.id,
-                round_id=round_data.id,
+                fund_short_name=fund.short_name,
+                round_short_name=round_data.short_name,
+                lang=application.language,
             ),
         )
 

--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -180,6 +180,11 @@ def tasklist(application_id):
             is_past_submission_deadline=current_datetime_after_given_iso_string(  # noqa:E501
                 round_data.deadline
             ),
+            all_questions_url=url_for(
+                "content_routes.all_questions",
+                fund_id=fund.id,
+                round_id=round_data.id,
+            ),
         )
 
 

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -1,3 +1,4 @@
+from app.default.data import get_round_data_by_short_names
 from app.default.data import get_round_data_fail_gracefully
 from config import Config
 from flask import Blueprint
@@ -5,7 +6,6 @@ from flask import current_app
 from flask import redirect
 from flask import render_template
 from flask import url_for
-from fsd_utils.config.commonconfig import CommonConfig
 
 content_bp = Blueprint("content_routes", __name__, template_folder="templates")
 
@@ -16,12 +16,17 @@ def accessibility_statement():
     return render_template("accessibility_statement.html")
 
 
-@content_bp.route("/all_questions/<fund_id>/<round_id>", methods=["GET"])
-def all_questions(fund_id, round_id):
-    current_app.logger.info(f"All questions page loaded for round {round_id}.")
-    round = get_round_data_fail_gracefully(fund_id, round_id)
+@content_bp.route(
+    "/all_questions/<fund_short_name>/<round_short_name>", methods=["GET"]
+)
+def all_questions(fund_short_name, round_short_name):
+    current_app.logger.info(
+        f"All questions page loaded for fund {fund_short_name} round"
+        f" {round_short_name}."
+    )
+    round = get_round_data_by_short_names(fund_short_name, round_short_name)
     return render_template(
-        "cof_r2_all_questions.html", round_title=round.title
+        "cof_r2_all_questions.html", round_title=round["title"]
     )
 
 
@@ -30,19 +35,8 @@ def cof_r2w2_all_questions_redirect():
     return redirect(
         url_for(
             "content_routes.all_questions",
-            fund_id=CommonConfig.COF_FUND_ID,
-            round_id=CommonConfig.COF_ROUND_2_ID,
-        )
-    )
-
-
-@content_bp.route("/cof_r2w3_all_questions", methods=["GET"])
-def cof_r2w3_all_questions_redirect():
-    return redirect(
-        url_for(
-            "content_routes.all_questions",
-            fund_id=CommonConfig.COF_FUND_ID,
-            round_id=CommonConfig.COF_ROUND_2_W3_ID,
+            fund_short_name="cof",
+            round_short_name="r2w2",
         )
     )
 

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -1,11 +1,11 @@
-
+from app.default.data import get_round_data_fail_gracefully
+from config import Config
 from flask import Blueprint
 from flask import current_app
-from config import Config
-from app.default.data import get_round_data_fail_gracefully
 from flask import render_template
 
 content_bp = Blueprint("content_routes", __name__, template_folder="templates")
+
 
 @content_bp.route("/accessibility_statement", methods=["GET"])
 def accessibility_statement():
@@ -13,10 +13,13 @@ def accessibility_statement():
     return render_template("accessibility_statement.html")
 
 
-@content_bp.route("/cof_r2w2_all_questions", methods=["GET"])
-def all_questions():
-    current_app.logger.info("All questions page loaded.")
-    return render_template("cof_r2w2_all_questions.html")
+@content_bp.route("/all_questions/<fund_id>/<round_id>", methods=["GET"])
+def all_questions(fund_id, round_id):
+    current_app.logger.info(f"All questions page loaded for round {round_id}.")
+    round = get_round_data_fail_gracefully(fund_id, round_id)
+    return render_template(
+        "cof_r2_all_questions.html", round_title=round.title
+    )
 
 
 @content_bp.route("/contact_us", methods=["GET"])

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -1,6 +1,7 @@
 from app.default.data import get_round_data_by_short_names
 from app.default.data import get_round_data_fail_gracefully
 from config import Config
+from flask import abort
 from flask import Blueprint
 from flask import current_app
 from flask import redirect
@@ -25,6 +26,8 @@ def all_questions(fund_short_name, round_short_name):
         f" {round_short_name}."
     )
     round = get_round_data_by_short_names(fund_short_name, round_short_name)
+    if not round:
+        return abort(404)
     return render_template(
         "cof_r2_all_questions.html", round_title=round["title"]
     )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -2,7 +2,10 @@ from app.default.data import get_round_data_fail_gracefully
 from config import Config
 from flask import Blueprint
 from flask import current_app
+from flask import redirect
 from flask import render_template
+from flask import url_for
+from fsd_utils.config.commonconfig import CommonConfig
 
 content_bp = Blueprint("content_routes", __name__, template_folder="templates")
 
@@ -19,6 +22,28 @@ def all_questions(fund_id, round_id):
     round = get_round_data_fail_gracefully(fund_id, round_id)
     return render_template(
         "cof_r2_all_questions.html", round_title=round.title
+    )
+
+
+@content_bp.route("/cof_r2w2_all_questions", methods=["GET"])
+def cof_r2w2_all_questions_redirect():
+    return redirect(
+        url_for(
+            "content_routes.all_questions",
+            fund_id=CommonConfig.COF_FUND_ID,
+            round_id=CommonConfig.COF_ROUND_2_ID,
+        )
+    )
+
+
+@content_bp.route("/cof_r2w3_all_questions", methods=["GET"])
+def cof_r2w3_all_questions_redirect():
+    return redirect(
+        url_for(
+            "content_routes.all_questions",
+            fund_id=CommonConfig.COF_FUND_ID,
+            round_id=CommonConfig.COF_ROUND_2_W3_ID,
+        )
     )
 
 

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -121,6 +121,23 @@ def get_round_data(fund_id, round_id, as_dict=False):
         return round_response
 
 
+def get_round_data_by_short_names(fund_short_name, round_short_name):
+    request_url = Config.GET_ALL_ROUNDS_FOR_FUND_ENDPOINT.format(
+        fund_id=fund_short_name
+    )
+    response = get_data(
+        request_url, {"language": get_lang(), "use_short_name": "true"}
+    )
+    return next(
+        (
+            round
+            for round in response
+            if str.upper(round["short_name"]) == str.upper(round_short_name)
+        ),
+        None,
+    )
+
+
 def get_round_data_fail_gracefully(fund_id, round_id):
     try:
         language = {"language": get_lang()}

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -132,7 +132,7 @@ def get_round_data_by_short_names(fund_short_name, round_short_name):
         (
             round
             for round in response
-            if str.upper(round["short_name"]) == str.upper(round_short_name)
+            if str.casefold(round["short_name"]) == str.casefold(round_short_name)
         ),
         None,
     )

--- a/app/templates/cof_r2_all_questions.html
+++ b/app/templates/cof_r2_all_questions.html
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l">{% trans %}Community Ownership Fund Round 2 Window 2{% endtrans %}</span>
+            <span class="govuk-caption-l">{% trans %}Community Ownership Fund {{round_title}}{% endtrans %}</span>
             <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
             <div class="govuk-!-margin-bottom-8">
                 <h2 class="govuk-heading-m ">{% trans %}Table of contents{% endtrans %}</h2>

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -23,7 +23,7 @@
                 <div class="govuk-details__text">
                     <h2 class="govuk-heading govuk-heading-s">{% trans %}What we'll ask you for{% endtrans %}</h2>
                     <p class="govuk-body">
-                        {% trans %}You can preview the{% endtrans %} <a class="govuk-link" href="/cof_r2w2_all_questions">{% trans %}full list of application questions{% endtrans %}</a>.
+                        {% trans %}You can preview the{% endtrans %} <a class="govuk-link" href="{{all_questions_url}}">{% trans %}full list of application questions{% endtrans %}</a>.
                     </p>
                     <p class="govuk-body">
                         {% trans %}We'll also ask you to upload a business plan to support the answers you've given us in the management case section.{% endtrans %}

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -1290,6 +1290,90 @@
   "account_store/accounts?account_id=test-user": {
         "account_id": "test-user",
         "email_address": "test@example.com"
-    }
-
+    },
+  "fund_store/funds/COF/rounds?language=en&use_short_name=true":
+    [
+      {
+        "assessment_criteria_weighting": [
+          {
+            "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
+            "name": "Strategic case",
+            "value": 0.3
+          },
+          {
+            "id": "e557773a-74c9-43ee-a52c-88ccae279d08",
+            "name": "Management case",
+            "value": 0.3
+          },
+          {
+            "id": "9e282cdb-6c42-4430-9563-dc4995b59bdd",
+            "name": "Potential to delivery community benefits",
+            "value": 0.3
+          },
+          {
+            "id": "6020db6c-df67-4932-a2f3-2e9dd1934164",
+            "name": "Added value to the community",
+            "value": 0.1
+          }
+        ],
+        "assessment_deadline": "2023-03-30 12:00:00",
+        "contact_details": {
+          "email_address": "COF@levellingup.gov.uk",
+          "phone": "",
+          "text_phone": ""
+        },
+        "deadline": "2022-12-14 11:59:00",
+        "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+        "id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
+        "opens": "2022-10-04 12:00:00",
+        "short_name": "R2W2",
+        "support_availability": {
+          "closed": "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day",
+          "days": "Monday to Friday",
+          "time": "9am to 5pm"
+        },
+        "title": "Round 2 Window 2"
+      },
+      {
+        "assessment_criteria_weighting": [
+          {
+            "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
+            "name": "Strategic case",
+            "value": 0.3
+          },
+          {
+            "id": "e557773a-74c9-43ee-a52c-88ccae279d08",
+            "name": "Management case",
+            "value": 0.3
+          },
+          {
+            "id": "9e282cdb-6c42-4430-9563-dc4995b59bdd",
+            "name": "Potential to delivery community benefits",
+            "value": 0.3
+          },
+          {
+            "id": "6020db6c-df67-4932-a2f3-2e9dd1934164",
+            "name": "Added value to the community",
+            "value": 0.1
+          }
+        ],
+        "assessment_deadline": "2023-05-05 12:00:00",
+        "contact_details": {
+          "email_address": "COF@levellingup.gov.uk",
+          "phone": "",
+          "text_phone": ""
+        },
+        "deadline": "2023-04-14 12:00:00",
+        "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+        "id": "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f",
+        "opens": "2023-02-15 12:00:00",
+        "short_name": "R2W3",
+        "support_availability": {
+          "closed": "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day",
+          "days": "Monday to Friday",
+          "time": "9am to 5pm"
+        },
+        "title": "Round 2 Window 3"
+      }
+    ]
   }

--- a/tests/test_all_questions.py
+++ b/tests/test_all_questions.py
@@ -1,0 +1,12 @@
+from bs4 import BeautifulSoup
+from werkzeug import test
+
+
+def test_all_questions_page_from_short_name(flask_test_client):
+    response: test.TestResponse = flask_test_client.get(
+        "/all_questions/COF/R2W3?lang=en"
+    )
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.data, "html.parser")
+    assert soup.find("h1").text == "Full list of application questions"
+    assert "Community Ownership Fund Round 2 Window 3" in soup.get_text()


### PR DESCRIPTION
Uses endpoint added in https://github.com/communitiesuk/funding-service-design-fund-store/pull/50

Updates:
- Change of URL to get to page showing all questions (now /all_questions/<fund_short_name>/<round_short_name> eg. `/all_questions/cof/r2w2`
- Redirect added so old url works (`/cof_r2w2_all_questions`)
- Goes along with changes to the fund store to be able to retrieve by short_name, and with the authenticator so it dynamically generates the link to the all questions page