### PR TITLE
BAU: Pass in Assessment frontend URL env var for e2e assessment

### DIFF
--- a/.github/workflows/build-deploy-forms.yml
+++ b/.github/workflows/build-deploy-forms.yml
@@ -97,6 +97,7 @@ jobs:
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
+      e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
       run_performance_tests: true
       run_e2e_tests: true
     secrets:
@@ -142,6 +143,7 @@ jobs:
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.test.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.test.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.test.gids.dev
+      e2e_tests_target_url_assessment: https://fsd:fsd@assessment.test.gids.dev
       run_performance_tests: true
       run_e2e_tests: true
     secrets:


### PR DESCRIPTION
Added env var for assessment as it was causing the e2e assessment test to fail when the workflow was running via application frontend.
https://github.com/communitiesuk/funding-service-design-frontend/actions/runs/4182482703/jobs/7245810232

