### PR TITLE
Fs 2308 cof h2s welsh

### DIFF
--- a/form_jsons/public/cy/buddion-cymunedol.json
+++ b/form_jsons/public/cy/buddion-cymunedol.json
@@ -13,7 +13,7 @@
           "name": "UiHVet",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Buddion cymunedol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut bydd yr ased o fudd i'r gymuned o dan eich perchnogaeth chi</h2>"
         },
         {
           "name": "QjJtbs",

--- a/form_jsons/public/cy/cefnogaeth-leol.json
+++ b/form_jsons/public/cy/cefnogaeth-leol.json
@@ -13,7 +13,7 @@
           "name": "tztfSa",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cefnogaeth leol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Eich cefnogaeth ar gyfer y prosiect</h2>"
         },
         {
           "name": "KqoaJL",
@@ -44,7 +44,7 @@
           "name": "abqMko",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cefnogaeth leol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Manylion cefnogaeth leol</h2>"
         },
         {
           "name": "BFbzux",

--- a/form_jsons/public/cy/costau'r-prosiect.json
+++ b/form_jsons/public/cy/costau'r-prosiect.json
@@ -11,7 +11,7 @@
           "name": "OdTNhg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Costau'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Llif arian i redeg yr ased</h2>"
         },
         {
           "name": "URmfYy",
@@ -59,7 +59,7 @@
           "name": "FHZRAe",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Costau'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Incwm i redeg yr ased</h2>"
         },
         {
           "name": "fzAoYw",
@@ -111,7 +111,7 @@
           "name": "MSEqcL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Costau'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Costau rhedeg yr ased</h2>"
         },
         {
           "name": "lIusUr",

--- a/form_jsons/public/cy/cyllid-sydd-ei-angen.json
+++ b/form_jsons/public/cy/cyllid-sydd-ei-angen.json
@@ -18,7 +18,7 @@
           "columnOneTitle": "Disgrifiad ",
           "columnTwoTitle": "Swm",
           "columnThreeTitle": "Gweithredu"
-          
+
         }
       },
       "components": [
@@ -26,7 +26,7 @@
           "name": "uKmWaC",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyllid cyfalaf ar gyfer eich prosiect</h2>"
         },
         {
           "name": "FhOGcz",
@@ -78,7 +78,7 @@
           "name": "eJdudr",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyllid refeniw ar gyfer eich prosiect</h2>"
         },
         {
           "name": "PZANlN",
@@ -131,7 +131,7 @@
           "name": "ZLsNnZ",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyllid cyfatebol a sicrhawyd ar gyfer eich prosiect</h2>"
         },
         {
           "name": "rgGQHh",
@@ -169,7 +169,7 @@
           "name": "PtVfWP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os ydych chi wedi sicrhau cyllid cyfatebol</h2>"
         },
         {
           "name": "DIZZOC",
@@ -192,7 +192,7 @@
           "name": "smwSHp",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Prisiad yr ased</h2>"
         },
         {
           "name": "cGVEui",
@@ -246,7 +246,7 @@
           "name": "sXyxUW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os ydych chi'n gwneud cais am gyllid refeniw</h2>"
         },
         {
           "name": "NWTKzQ",
@@ -270,7 +270,7 @@
           "name": "NcZEsI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os ydych chi wedi nodi cyllid cyfatebol pellach</h2>"
         },
         {
           "name": "RvbwSX",
@@ -307,7 +307,7 @@
           "name": "oHcGUy",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyllid cyfatebol a nodwyd ar gyfer eich prosiect</h2>"
         },
         {
           "name": "RafXFy",
@@ -345,7 +345,7 @@
           "name": "VfUORj",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cyllid sydd ei angen</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyfanswm y cais am gyllid gan y Gronfa Perchnogaeth Gymunedol</h2>"
         },
         {
           "name": "XcjQVp",

--- a/form_jsons/public/cy/cymhwystra'r-prosiect.json
+++ b/form_jsons/public/cy/cymhwystra'r-prosiect.json
@@ -13,7 +13,7 @@
           "name": "jsBTOY",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cymhwystra'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os yw eich prosiect yn bodloni'r diffiniad</h2>"
         },
         {
           "name": "HvxXPI",
@@ -45,7 +45,7 @@
           "name": "IoCBIO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cymhwystra'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut bydd eich prosiect yn cydymffurfio â'r rheoliadau</h2>"
         },
         {
           "name": "RmMKzM",
@@ -93,7 +93,7 @@
           "name": "tYvkAL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cymhwystra'r prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut bydd eich prosiect yn cydymffurfio â rheolau cymorth gwladol</h2>"
         },
         {
           "name": "xPkdRX",

--- a/form_jsons/public/cy/cynaliadwyedd-amgylcheddol.json
+++ b/form_jsons/public/cy/cynaliadwyedd-amgylcheddol.json
@@ -13,7 +13,7 @@
           "name": "WnykzV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cynaliadwyedd amgylcheddol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut ydych chi wedi ystyried yr amgylchedd</h2>"
         },
         {
           "name": "CvVZJv",

--- a/form_jsons/public/cy/cynhwysiant-ac-integreiddio.json
+++ b/form_jsons/public/cy/cynhwysiant-ac-integreiddio.json
@@ -13,7 +13,7 @@
           "name": "XWvsQw",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cynhwysiant ac integreiddio</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut byddwch chi'n gwneud yr ased yn gynhwysol</h2>"
         },
         {
           "name": "SrtVAs",

--- a/form_jsons/public/cy/cynrychiolaeth-gymunedol.json
+++ b/form_jsons/public/cy/cynrychiolaeth-gymunedol.json
@@ -13,7 +13,7 @@
           "name": "GHjwwB",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cynrychiolaeth gymunedol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut byddwch chi'n rhedeg yr ased</h2>"
         },
         {
           "name": "JnvsPq",

--- a/form_jsons/public/cy/datganiadau.json
+++ b/form_jsons/public/cy/datganiadau.json
@@ -11,7 +11,7 @@
           "name": "sBiSgs",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cadarnhadau terfynol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Datganiadau'r cais</h2>"
         },
         {
           "name": "LlvhYl",

--- a/form_jsons/public/cy/defnydd-cymunedol.json
+++ b/form_jsons/public/cy/defnydd-cymunedol.json
@@ -11,7 +11,7 @@
           "name": "AwAAQG",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Defnydd cymunedol</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Pwy sy'n defnyddio'r ased ac yn elwa ohono</h2>"
         },
         {
           "name": "CDwTrG",

--- a/form_jsons/public/cy/dichonoldeb.json
+++ b/form_jsons/public/cy/dichonoldeb.json
@@ -13,7 +13,7 @@
           "name": "VjoSon",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Dichonoldeb</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Astudiaethau dichonoldeb a gynhalioch</h2>"
         },
         {
           "name": "FIKWHB",

--- a/form_jsons/public/cy/gwerth-i'r-gymuned.json
+++ b/form_jsons/public/cy/gwerth-i'r-gymuned.json
@@ -13,7 +13,7 @@
           "name": "zbEFpO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwerth i'r gymuned</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y gymuned ehangach</h2>"
         },
         {
           "name": "oOPUXI",

--- a/form_jsons/public/cy/gwybodaeth-am-y-prosiect.json
+++ b/form_jsons/public/cy/gwybodaeth-am-y-prosiect.json
@@ -37,7 +37,7 @@
           "name": "aVhByI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyllid blaenorol gan y Gronfa Perchnogaeth Gymunedol</h2>"
         },
         {
           "name": "gScdbf",
@@ -67,7 +67,7 @@
           "name": "tmVEPV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Prosiectau a ariannwyd yn flaenorol gan y Gronfa Perchnogaeth Gymunedol</h2>"
         },
         {
           "name": "IrIYcA",
@@ -103,7 +103,7 @@
           "name": "umDxBP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Enw'r prosiect a chrynodeb ohono</h2>"
         },
         {
           "name": "KAgrBz",
@@ -153,7 +153,7 @@
           "name": "tpQVaN",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y prosiect</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cyfeiriad yr ased</h2>"
         },
         {
           "name": "yEmHpp",

--- a/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
+++ b/form_jsons/public/cy/gwybodaeth-am-y-sefydliad.json
@@ -39,7 +39,7 @@
           "name": "uNgkim",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Enwau'r sefydliad</h2>",
           "schema": {}
         },
         {
@@ -92,7 +92,7 @@
           "name": "wnoFHW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Enwau'r sefydliad</h2>",
           "schema": {}
         },
         {
@@ -159,7 +159,7 @@
           "name": "KYKyud",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Diben a gweithgareddau</h2>",
           "schema": {}
         },
         {
@@ -251,7 +251,7 @@
           "name": "QuTAqW",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Prosiectau blaenorol sy'n debyg i'r prosiect hwn</h2>",
           "schema": {}
         },
         {
@@ -318,7 +318,7 @@
           "name": "pTuytP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Sut mae eich sefydliad yn cael ei ddosbarthu</h2>",
           "schema": {}
         },
         {
@@ -357,7 +357,7 @@
           "name": "QzkrIE",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Sut mae eich sefydliad yn cael ei ddosbarthu</h2>",
           "schema": {}
         },
         {
@@ -384,7 +384,7 @@
           "name": "toyZsH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion cofrestru</h2>",
           "schema": {}
         },
         {
@@ -418,7 +418,7 @@
           "name": "rHMVcR",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion cofrestru'r elusen</h2>",
           "schema": {}
         },
         {
@@ -445,7 +445,7 @@
           "name": "MgmuIz",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Is-gwmnïau masnachu</h2>",
           "schema": {}
         },
         {
@@ -478,7 +478,7 @@
           "name": "UNQlIu",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion rhiant-sefydliad</h2>",
           "schema": {}
         },
         {
@@ -513,7 +513,7 @@
           "name": "vRPbaz",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Cyfeiriad a chyfrifon cyfryngau cymdeithasol</h2>",
           "schema": {}
         },
         {
@@ -602,7 +602,7 @@
           "name": "WYZWDE",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Cyfeiriad gohebu</h2>",
           "schema": {}
         },
         {
@@ -627,7 +627,7 @@
           "name": "OKCdpZ",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Ceisiadau ar y cyd</h2>",
           "schema": {}
         },
         {
@@ -660,7 +660,7 @@
           "name": "YnSQGx",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion sefydliad partner</h2>",
           "schema": {}
         },
         {
@@ -712,7 +712,7 @@
           "name": "TUqPvI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion cofrestru'r cwmni</h2>",
           "schema": {}
         },
         {
@@ -739,7 +739,7 @@
           "name": "nITyAP",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am y sefydliad</h2>",
+          "content": "<h2 class=\"govuk-heading-m\">Manylion cofrestru</h2>",
           "schema": {}
         },
         {

--- a/form_jsons/public/cy/gwybodaeth-am-yr-ased.json
+++ b/form_jsons/public/cy/gwybodaeth-am-yr-ased.json
@@ -13,7 +13,7 @@
           "name": "pkTHJq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut caiff yr ased ei ddefnyddio yn y gymuned</h2>"
         },
         {
           "name": "yaQoxU",
@@ -45,7 +45,7 @@
           "name": "LjSaeq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut caiff yr ased ei ddefnyddio yn y gymuned</h2>"
         },
         {
           "name": "GjzaqR",
@@ -68,7 +68,7 @@
           "name": "nouxzF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut byddwch yn berchen ar yr ased neu'n prydlesu'r ased</h2>"
         },
         {
           "name": "VWkLlk",
@@ -109,7 +109,7 @@
           "name": "Fmluly",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Pwy sy'n berchen ar yr ased ar hyn o bryd</h2>"
         },
         {
           "name": "ymlmrX",
@@ -134,7 +134,7 @@
           "name": "bLCDBI",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os ydych eisoes yn berchen arno</h2>"
         },
         {
           "name": "gkulUE",
@@ -165,7 +165,7 @@
           "name": "fJVdgL",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Statws perchnogaeth bresennol</h2>"
         },
         {
           "name": "FtDJfK",
@@ -190,7 +190,7 @@
           "name": "lusfLU",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Telerau eich perchnogaeth neu'ch prydles</h2>"
         },
         {
           "name": "uBXptf",
@@ -216,7 +216,7 @@
           "name": "MRrIQO",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Telerau disgwyliedig eich perchnogaeth neu'ch prydles</h2>"
         },
         {
           "name": "nvMmGE",
@@ -249,7 +249,7 @@
           "name": "gaXSIn",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Perchnogaeth gyhoeddus</h2>"
         },
         {
           "name": "Wyesgy",
@@ -279,7 +279,7 @@
           "name": "PoZmwV",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Manylion a datganiadau perchnogaeth gyhoeddus</h2>"
         },
         {
           "name": "fHvilU",
@@ -349,7 +349,7 @@
           "name": "ZyEFDq",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Asedau o Werth Cymunedol</h2>"
         },
         {
           "name": "hvzzWB",
@@ -379,7 +379,7 @@
           "name": "cQpClK",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Prynu o fewn yr amserlen</h2>"
         },
         {
           "name": "MLwpjP",
@@ -405,7 +405,7 @@
           "name": "iZzvMF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Asedau a restrwyd i'w gwaredu</h2>"
         },
         {
           "name": "VwxiGn",
@@ -435,7 +435,7 @@
           "name": "LfCMtg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Manylion rhestru'r ased</h2>"
         },
         {
           "name": "bkbGIE",
@@ -475,7 +475,7 @@
           "name": "ZCNFUF",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ased</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Risg cau</h2>"
         },
         {
           "name": "UDTxqC",

--- a/form_jsons/public/cy/gwybodaeth-am-yr-ymgeisydd.json
+++ b/form_jsons/public/cy/gwybodaeth-am-yr-ymgeisydd.json
@@ -11,7 +11,7 @@
           "name": "ZAKTgH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Gwybodaeth am yr ymgeisydd</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Manylion y prif gyswllt</h2>"
         },
         {
           "name": "ZBjDTn",

--- a/form_jsons/public/cy/lanlwythwch-y-cynllun-busnes.json
+++ b/form_jsons/public/cy/lanlwythwch-y-cynllun-busnes.json
@@ -38,7 +38,7 @@
           "name": "QAgOjR",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Cynllun busnes</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Eich cynllun busnes</h2>"
         },
         {
           "name": "qZNAHj",

--- a/form_jsons/public/cy/risg.json
+++ b/form_jsons/public/cy/risg.json
@@ -11,7 +11,7 @@
           "name": "nDfjRY",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Risg</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cofrestr risg eich prosiect</h2>"
         },
         {
           "name": "LVXUhZ",

--- a/form_jsons/public/cy/sgiliau-ac-adnoddau.json
+++ b/form_jsons/public/cy/sgiliau-ac-adnoddau.json
@@ -13,7 +13,7 @@
           "name": "jdiAQM",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Sgiliau ac adnoddau</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Os oes gennych brofiad o redeg asedau tebyg</h2>"
         },
         {
           "name": "eenpQC",
@@ -50,7 +50,7 @@
           "name": "KVYefk",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Sgiliau ac adnoddau</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Cynlluniau recriwtio</h2>"
         },
         {
           "name": "uMhZAI",
@@ -94,7 +94,7 @@
           "name": "SUVlQH",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Sgiliau ac adnoddau</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Eich profiad o redeg asedau tebyg</h2>"
         },
         {
           "name": "pepEsp",
@@ -126,7 +126,7 @@
           "name": "OtWwRe",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Sgiliau ac adnoddau</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Rolau y byddwch yn recriwtio iddynt i'ch helpu i redeg yr ased</h2>"
         },
         {
           "name": "mxgewf",

--- a/form_jsons/public/cy/ymgysylltu-a'r-gymuned.json
+++ b/form_jsons/public/cy/ymgysylltu-a'r-gymuned.json
@@ -11,7 +11,7 @@
           "name": "Skuupp",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Ymgysylltu â'r gymuned</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Sut ydych chi wedi ymgysylltu â'r gymuned ynghylch yr ased</h2>"
         },
         {
           "name": "HJBgvw",
@@ -40,7 +40,7 @@
           "name": "mCOxVf",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Ymgysylltu â'r gymuned</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Eich prosiect a'ch cynlluniau ehangach</h2>"
         },
         {
           "name": "NZKHOp",
@@ -66,7 +66,7 @@
           "name": "EjFSzg",
           "options": {},
           "type": "Html",
-          "content": "<h2 class=\"govuk-heading-m\">Ymgysylltu â'r gymuned</h2>"
+          "content": "<h2 class=\"govuk-heading-m\">Eich gweithgareddau codi arian</h2>"
         },
         {
           "name": "dpLyQh",


### PR DESCRIPTION
Change description
A brief description of the pull request

Removing duplicated page titles in form runner form configuration, this issue was raised in the DAC Accessibility Report (Pages 15-16).

[V ] Unit tests and other appropriate tests added or updated
[V] README and other documentation has been updated / added (if needed)
[V] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
How to test
If manual testing is needed, give suggested testing steps
This can be tested by ensuring the correct title displays in e2e (pick up h2s) and exploratory testing whilst navigating through the journey.

Screenshots of UI changes (if applicable)