### PR TITLE
FS-1200: Enable performance tests for Assessment store to run in the pipelines

### DIFF
--- a/.github/workflows/build-deploy-forms.yml
+++ b/.github/workflows/build-deploy-forms.yml
@@ -96,6 +96,7 @@ jobs:
     with:
       perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
       perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
+      perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
@@ -142,6 +143,7 @@ jobs:
     with:
       perf_test_target_url_application_store: https://funding-service-design-application-store-test.london.cloudapps.digital
       perf_test_target_url_fund_store: https://funding-service-design-fund-store-test.london.cloudapps.digital
+      perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-test.london.cloudapps.digital
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.test.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.test.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.test.gids.dev

--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -100,6 +100,7 @@ jobs:
     with:
       perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
       perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
+      perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
@@ -161,6 +162,7 @@ jobs:
     with:
       perf_test_target_url_application_store: https://funding-service-design-application-store-test.london.cloudapps.digital
       perf_test_target_url_fund_store: https://funding-service-design-fund-store-test.london.cloudapps.digital
+      perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-test.london.cloudapps.digital
       e2e_tests_target_url_frontend: https://fsd:fsd@frontend.test.gids.dev
       e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.test.gids.dev
       e2e_tests_target_url_form_runner: https://fsd:fsd@forms.test.gids.dev


### PR DESCRIPTION
### Change description
https://digital.dclg.gov.uk/jira/browse/FS-1200

Added assessment store url to enable performance tests for Assessment store.


### How to test
N/A

### Screenshot of UI changes
N/A

