### PR TITLE
Revert "Bump zaproxy/action-full-scan from 0.3.0 to 0.4.0"

### DIFF
--- a/.github/workflows/govcloud.yml
+++ b/.github/workflows/govcloud.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Bandit
         run: bandit -r ./app
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.4.0
+        uses: zaproxy/action-full-scan@v0.3.0
         with:
           target: "https://funding-service-design-frontend-dev.london.cloudapps.digital"
           allow_issue_writing: False


### PR DESCRIPTION
Reverts communitiesuk/funding-service-design-frontend#153

Looks like this workflow update doesn't work.  Reverting it for now.