### PR TITLE
hotfix - filter out favicon requests and check for valid fund short code

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -6,9 +6,11 @@ from app.filters import datetime_format_short_month
 from app.filters import kebab_case_to_human
 from app.filters import snake_case_to_human
 from app.filters import status_translation
+from app.models.fund import FUND_SHORT_CODES
 from config import Config
 from flask import current_app
 from flask import Flask
+from flask import make_response
 from flask import request
 from flask_babel import Babel
 from flask_babel import gettext
@@ -106,10 +108,11 @@ def create_app() -> Flask:
     def inject_service_name():
         fund = None
         try:
-            if request.view_args.get("fund_short_name"):
-                fund = get_fund_data_by_short_name(
-                    request.view_args.get("fund_short_name")
-                )
+            fund_short_name = request.view_args.get("fund_short_name")
+            if fund_short_name and str.upper(fund_short_name) in [
+                member.value for member in FUND_SHORT_CODES
+            ]:
+                fund = get_fund_data_by_short_name(fund_short_name)
             elif request.view_args.get("fund_id"):
                 fund = get_fund_data(request.view_args.get("fund_id"), True)
             elif request.args.get("fund_id"):
@@ -125,6 +128,11 @@ def create_app() -> Flask:
                 Config.DEFAULT_FUND_ID, as_dict=True
             ).title
         return dict(service_title=gettext("Apply for") + " " + service_title)
+
+    @flask_app.before_request
+    def filter_favicon_requests():
+        if request.path == "/favicon.ico":
+            return make_response("404"), 404
 
     health = Healthcheck(flask_app)
     health.add_check(FlaskRunningChecker())

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -2,6 +2,8 @@ from app.default.data import determine_round_status
 from app.default.data import get_default_round_for_fund
 from app.default.data import get_fund_data_by_short_name
 from app.default.data import get_round_data_by_short_names
+from app.models.fund import FUND_SHORT_CODES
+from app.models.round import Round
 from config import Config
 from flask import abort
 from flask import Blueprint
@@ -56,14 +58,25 @@ def index_fund_round(fund_short_name, round_short_name):
 
 @default_bp.route("/<fund_short_name>")
 def index_fund_only(fund_short_name):
-    current_app.logger.info(
-        f"In fund-only start page route for {fund_short_name}"
-    )
-    default_round = get_default_round_for_fund(fund_short_name=fund_short_name)
-    if default_round:
-        return redirect(f"/{fund_short_name}/{default_round.short_name}")
-    else:
+    if str.upper(fund_short_name) in [
+        member.value for member in FUND_SHORT_CODES
+    ]:
+        current_app.logger.info(
+            f"In fund-only start page route for {fund_short_name}"
+        )
+        default_round = get_default_round_for_fund(
+            fund_short_name=fund_short_name
+        )
+        if default_round:
+            return redirect(f"/{fund_short_name}/{default_round.short_name}")
+
         current_app.logger.warn(
             f"Unable to retrieve default round for fund {fund_short_name}"
         )
-        abort(404)
+    return (
+        render_template(
+            "404.html",
+            round_data=Round("", [], "", "", "", "", "", "", "", "", {}, {}),
+        ),
+        404,
+    )

--- a/app/models/fund.py
+++ b/app/models/fund.py
@@ -1,5 +1,10 @@
 import inspect
 from dataclasses import dataclass
+from enum import Enum
+
+
+class FUND_SHORT_CODES(Enum):
+    COF = "COF"
 
 
 @dataclass

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -64,7 +64,7 @@ default_fund = Fund(**fund_args, title="Default Fund")
 @pytest.mark.parametrize(
     "key_name, view_args_value, args_value, expected_title",
     [
-        ("fund_short_name", "TEST", None, short_name_fund.title),
+        ("fund_short_name", "COF", None, short_name_fund.title),
         ("fund_short_name", None, None, default_fund.title),
         ("fund_short_name", None, "TEST", default_fund.title),
         ("fund_id", "TEST", None, id_fund.title),

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -208,3 +208,9 @@ def test_fund_only_start_page_bad_fund(client):
         mock_get_rounds.side_effect = Exception
         result = client.get("/asdf", follow_redirects=False)
         assert result.status_code == 404
+
+
+def test_favicon_filter(client):
+    result = client.get("/favicon.ico", follow_redirects=False)
+    assert result.status_code == 404
+    assert result.data == b"404"


### PR DESCRIPTION
Hotfix


### Change description
We are seeing errors in Sentry (eg. https://funding-service-design-team-dl.sentry.io/issues/4061658169/) following release of the new routes in frontend to support eg. frontend.dev.gids.dev/cof redirecting to /cof/r2w3. The requests for /favicon.ico are generating lots of noise in the logs as we don't have a fund called 'favicon.ico'.

This change tackles this in the following ways:
- Adds a `before_request` filter to return a simple 404 when someone asks for /favicon.ico (not the full 404 page as that also tries to retrieve fund details)
- Checks for all requests to /something_else whether something_else is a valid fund short code.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Navigate to the following URLs when running the docker-runner locally:
- http://localhost:3008/cof/r2w3 - should return 200
- http://localhost:3008/cof/ - should redirect to http://localhost:3008/cof/r2w3
- http://localhost:3008/rubbish - should return a full 404 page
- http://localhost:3008/ - should redirect to http://localhost:3008/cof/r2w3
- http://localhost:3008/favicon.ico - should return a simple 404 status code


### Screenshots of UI changes (if applicable)
n/a