### PR TITLE
bau fail gracefully on incorrect request

### DIFF
--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -20,22 +20,18 @@ def index():
     Redirects from the old landing page to the new one at /cof/r2w3
     """
     current_app.logger.info("Redirecting from index to /cof/r2w3")
-    return redirect("/cof/r2w3")
+    return redirect("funding-round/cof/r2w3")
 
 
-@default_bp.route("/<fund_short_name>/<round_short_name>")
+@default_bp.route("/funding-round/<fund_short_name>/<round_short_name>")
 def index_fund_round(fund_short_name, round_short_name):
     current_app.logger.info(
         f"In fund-round start page {fund_short_name} {round_short_name}"
     )
     fund_data = get_fund_data_by_short_name(fund_short_name, as_dict=False)
-    if not fund_data:
-        abort(404)
     round_data = get_round_data_by_short_names(
         fund_short_name, round_short_name
     )
-    if not round_data:
-        abort(404)
     round_status = determine_round_status(round_data)
     if round_status.not_yet_open:
         abort(404)
@@ -56,7 +52,7 @@ def index_fund_round(fund_short_name, round_short_name):
     )
 
 
-@default_bp.route("/<fund_short_name>")
+@default_bp.route("/funding-round/<fund_short_name>")
 def index_fund_only(fund_short_name):
     if str.upper(fund_short_name) in [
         member.value for member in FUND_SHORT_CODES

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -64,7 +64,7 @@ def index_fund_only(fund_short_name):
             fund_short_name=fund_short_name
         )
         if default_round:
-            return redirect(f"/{fund_short_name}/{default_round.short_name}")
+            return redirect(f"/funding-round/{fund_short_name}/{default_round.short_name}")
 
         current_app.logger.warn(
             f"Unable to retrieve default round for fund {fund_short_name}"

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -47,14 +47,22 @@ def mock_get_round(mocker):
 def test_old_index_redirect(client):
     result = client.get("/", follow_redirects=False)
     assert result.status_code == 302
-    assert result.location == "/cof/r2w3"
+    assert result.location == "funding-round/cof/r2w3"
 
 
 def test_start_page_unknown_fund(client, mocker):
     mocker.patch(
         "app.default.routes.get_fund_data_by_short_name", return_value=None
     )
-    result = client.get("/bad_fund/r2w2")
+    result = client.get("funding-round/bad_fund/r2w2")
+    assert result.status_code == 404
+
+
+def test_start_page_without_namespace(client, mocker):
+    mocker.patch(
+        "app.default.routes.get_fund_data_by_short_name", return_value=None
+    )
+    result = client.get("cof/r2w2")
     assert result.status_code == 404
 
 
@@ -84,7 +92,7 @@ def test_start_page_open(
         "app.default.routes.determine_round_status",
         return_value=RoundStatus(False, False, True),
     )
-    result = client.get("/cof/r2w3")
+    result = client.get("funding-round/cof/r2w3")
     assert result.status_code == 200
     assert 1 == len(templates_rendered)
     rendered_template = templates_rendered[0]
@@ -101,7 +109,7 @@ def test_start_page_closed(
         "app.default.routes.determine_round_status",
         return_value=RoundStatus(True, False, False),
     )
-    result = client.get("/cof/r2w3")
+    result = client.get("funding-round/cof/r2w3")
     assert result.status_code == 200
     assert 1 == len(templates_rendered)
     rendered_template = templates_rendered[0]
@@ -188,9 +196,9 @@ def test_fund_only_start_page(client, mocker):
             id="111", deadline="", opens="", **default_round_fields
         ),
     )
-    result = client.get("/cof", follow_redirects=False)
+    result = client.get("funding-round/cof", follow_redirects=False)
     assert result.status_code == 302
-    assert result.location == "/cof/SHORT"
+    assert result.location == "/funding-round/cof/SHORT"
 
 
 def test_fund_only_start_page_no_rounds(client, mocker):


### PR DESCRIPTION
After releasing the multifund changes in frontend where the URL string now directs the user to the respective landing page for the fund and round, we have had misuse of this where requests have ben made using non-existent fund and rounds by editing the URL string directly. 
This makes a call to the fund store which returns a 404, however the get_data() function in frontend forces a 500 and aborts by default if no data was found when making the call.
Another function called get_data_or_fail_gracefully() has been added which is a direct copy of the above get_data() function but does not force the 500 and instead returns a 404. This means we can use this functionality in the future without compromising existing functionality that might depend on the abort 500 returned by get_data() when no data is returned.