### PR TITLE
bau-change-uneccessary-error-logging-to-warn

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -120,7 +120,10 @@ def create_app() -> Flask:
             elif request.args.get("fund"):
                 fund = get_fund_data_by_short_name(request.args.get("fund"))
         except Exception as e:  # noqa
-            current_app.log_exception(e)
+            current_app.logger.warn(
+            f"""Exception: {e}, occured when trying to reach url: {request.url}, 
+            with view_args: {request.view_args}, and args: {request.args}"""
+        )
         if fund:
             service_title = fund.title
         else:


### PR DESCRIPTION
In front-end, in our create_app function we are inject the fund title dynamically using inject_service_name(). However when someone has misused the service and entered the url manually themselves an error is raised which we are catching and then logging, returning a 404 back to the user as desired behavior. However Sentry is reporting on these logged errors which we don't need/ is unnecessary. 
To fix this we are now logging using current_app.logger.warn() instead and are logging the exception, url, view_args and args using it. This way Sentry will not flag these but we can still see how the error had occurred should we need to. 