### PR TITLE
Privacy Notice link in footer is dynamic and has fallback

### DIFF
--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -71,10 +71,10 @@ def privacy():
     if privacy_notice_url:
         current_app.logger.warning("Privacy notice configured for fund")
         return redirect(privacy_notice_url)
-
-    current_app.logger.warning(
-        "No privacy notice configured for fund. Redirecting..."
-    )
-    return redirect(
-        "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
-    )
+    else:
+        current_app.logger.warning(
+            "No privacy notice configured for fund. Redirecting..."
+        )
+        return redirect(
+            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
+        )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -29,7 +29,7 @@ def all_questions(fund_short_name, round_short_name):
     if not round:
         return abort(404)
     return render_template(
-        "cof_r2_all_questions.html", round_title=round["title"]
+        "cof_r2_all_questions.html", round_title=round.title
     )
 
 

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -66,11 +66,11 @@ def privacy():
         Config.DEFAULT_FUND_ID, Config.DEFAULT_ROUND_ID
     )
 
-    privacy_notice_url = None
-    try:
-        privacy_notice_url = round_data.privacy_notice
-        return redirect(privacy_notice_url)
+    privacy_notice_url = round_data.privacy_notice if hasattr(round_data, 'privacy_notice') else None
 
-    except AttributeError:
-        print("Error finding privacy notice for fund, redirecting")
+    if privacy_notice_url:
+        current_app.logger.warning("Privacy notice configured for fund")
+        return redirect(privacy_notice_url)
+    else:
+        current_app.logger.warning("No privacy notice configured for fund. Redirecting...")
         return redirect('https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice')

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -66,11 +66,19 @@ def privacy():
         Config.DEFAULT_FUND_ID, Config.DEFAULT_ROUND_ID
     )
 
-    privacy_notice_url = round_data.privacy_notice if hasattr(round_data, 'privacy_notice') else None
+    privacy_notice_url = (
+        round_data.privacy_notice
+        if hasattr(round_data, "privacy_notice")
+        else None
+    )
 
     if privacy_notice_url:
         current_app.logger.warning("Privacy notice configured for fund")
         return redirect(privacy_notice_url)
     else:
-        current_app.logger.warning("No privacy notice configured for fund. Redirecting...")
-        return redirect('https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice')
+        current_app.logger.warning(
+            "No privacy notice configured for fund. Redirecting..."
+        )
+        return redirect(
+            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
+        )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -76,5 +76,5 @@ def privacy():
             "No privacy notice configured for fund. Redirecting..."
         )
         return redirect(
-            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
+            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"    # noqa
         )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -71,7 +71,7 @@ def privacy():
     if privacy_notice_url:
         current_app.logger.warning("Privacy notice configured for fund")
         return redirect(privacy_notice_url)
-    
+
     current_app.logger.warning(
         "No privacy notice configured for fund. Redirecting..."
     )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -66,11 +66,7 @@ def privacy():
         Config.DEFAULT_FUND_ID, Config.DEFAULT_ROUND_ID
     )
 
-    privacy_notice_url = (
-        round_data.privacy_notice
-        if hasattr(round_data, "privacy_notice")
-        else None
-    )
+    privacy_notice_url = getattr(round_data, "privacy_notice", None)
 
     if privacy_notice_url:
         current_app.logger.warning("Privacy notice configured for fund")

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -76,5 +76,5 @@ def privacy():
             "No privacy notice configured for fund. Redirecting..."
         )
         return redirect(
-            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"    # noqa
+            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"  # noqa
         )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -1,6 +1,7 @@
 from app.default.data import get_round_data_by_short_names
 from app.default.data import get_round_data_fail_gracefully
 from config import Config
+from flask import abort
 from flask import Blueprint
 from flask import current_app
 from flask import redirect
@@ -25,8 +26,10 @@ def all_questions(fund_short_name, round_short_name):
         f" {round_short_name}."
     )
     round = get_round_data_by_short_names(fund_short_name, round_short_name)
+    if not round:
+        return abort(404)
     return render_template(
-        "cof_r2_all_questions.html", round_title=round.title
+        "cof_r2_all_questions.html", round_title=round["title"]
     )
 
 
@@ -54,3 +57,20 @@ def contact_us():
 def cookie_policy():
     current_app.logger.info("Cookie policy page loaded.")
     return render_template("cookie_policy.html")
+
+
+@content_bp.route("/privacy", methods=["GET"])
+def privacy():
+    current_app.logger.info("Privacy_notice page loaded.")
+    round_data = get_round_data_fail_gracefully(
+        Config.DEFAULT_FUND_ID, Config.DEFAULT_ROUND_ID
+    )
+
+    privacy_notice_url = None
+    try:
+        privacy_notice_url = round_data.privacy_notice
+        return redirect(privacy_notice_url)
+
+    except AttributeError:
+        print("Error finding privacy notice for fund, redirecting")
+        return redirect('https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice')

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -71,10 +71,10 @@ def privacy():
     if privacy_notice_url:
         current_app.logger.warning("Privacy notice configured for fund")
         return redirect(privacy_notice_url)
-    else:
-        current_app.logger.warning(
-            "No privacy notice configured for fund. Redirecting..."
-        )
-        return redirect(
-            "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
-        )
+    
+    current_app.logger.warning(
+        "No privacy notice configured for fund. Redirecting..."
+    )
+    return redirect(
+        "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"
+    )

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -229,7 +229,21 @@ def get_round_data_fail_gracefully(fund_id, round_id):
         )
         # return valid Round object with no values so we know we've
         # failed and can handle in templates appropriately
-        return Round(id="", assessment_criteria_weighting=[], assessment_deadline="", deadline="", fund_id="", opens="", title="", short_name="", prospectus="", privacy_notice="", instructions="", contact_details={}, support_availability={})
+        return Round(
+            id="",
+            assessment_criteria_weighting=[],
+            assessment_deadline="",
+            deadline="",
+            fund_id="",
+            opens="",
+            title="",
+            short_name="",
+            prospectus="",
+            privacy_notice="",
+            instructions="",
+            contact_details={},
+            support_availability={},
+        )
 
 
 def get_account(email: str = None, account_id: str = None) -> Account | None:

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -229,7 +229,7 @@ def get_round_data_fail_gracefully(fund_id, round_id):
         )
         # return valid Round object with no values so we know we've
         # failed and can handle in templates appropriately
-        return Round("", [], "", "", "", "", "", "", "", "", {}, {})
+        return Round(id="", assessment_criteria_weighting=[], assessment_deadline="", deadline="", fund_id="", opens="", title="", short_name="", prospectus="", privacy_notice="", instructions="", contact_details={}, support_availability={})
 
 
 def get_account(email: str = None, account_id: str = None) -> Account | None:

--- a/app/models/round.py
+++ b/app/models/round.py
@@ -51,6 +51,7 @@ class Round:
     title: str
     short_name: str
     prospectus: str
+    privacy_notice: str
     instructions: str
     contact_details: ContactDetails
     support_availability: SupportAvailability

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -6,7 +6,7 @@
             'visuallyHiddenTitle': 'Support links',
             'items': [
                 {
-                    'href': 'https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice',
+                    'href': '/privacy',
                     'text': gettext('Privacy')
 
                 },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,8 @@ async-timeout==4.0.2
     # via
     #   -r requirements.txt
     #   redis
+atomicwrites==1.4.1
+    # via pytest
 attrs==21.4.0
     # via
     #   outcome
@@ -64,6 +66,7 @@ cffi==1.15.1
     # via
     #   -r requirements.txt
     #   cryptography
+    #   trio
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==2.1.0
@@ -76,6 +79,14 @@ click==8.1.3
     #   black
     #   flask
     #   pip-tools
+colorama==0.4.6
+    # via
+    #   -r requirements.txt
+    #   bandit
+    #   build
+    #   click
+    #   pytest
+    #   tqdm
 commonmark==0.9.1
     # via
     #   -r requirements.txt
@@ -154,6 +165,10 @@ gitpython==3.1.27
     # via bandit
 govuk-frontend-jinja==2.0.0
     # via -r requirements.txt
+greenlet==2.0.2
+    # via
+    #   -r requirements.txt
+    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,8 @@ charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via flask
+colorama==0.4.6
+    # via click
 commonmark==0.9.1
     # via rich
 cryptography==37.0.4
@@ -80,6 +82,8 @@ funding-service-design-utils==1.0.30
     # via -r requirements.in
 govuk-frontend-jinja==2.0.0
     # via -r requirements.in
+greenlet==2.0.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via funding-service-design-utils
 idna==3.3

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -28,6 +28,7 @@
       "contact_details": {},
       "support_availability": {},
       "prospectus": "/cof_r2w2_prospectus",
+      "privacy_notice": "",
       "instructions": "Round specific instruction text"
     },
     {
@@ -42,6 +43,7 @@
       "contact_details": {},
       "support_availability": {},
       "prospectus": "/fsd_r2w3_prospectus",
+      "privacy_notice": "",
       "instructions": "Round specific instruction text"
     }
 
@@ -58,6 +60,7 @@
     "title": "Round 2 Window 2",
     "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
     "prospectus": "our_prospectus.html",
+    "privacy_notice": "",
     "instructions": "Round specific instruction text",
     "short_name": "R2W2",
     "assessment_criteria_weighting": [
@@ -103,6 +106,7 @@
     "short_name": "R2W3",
     "instructions": "Round specific instruction text",
     "prospectus": "/prospectus_link",
+    "privacy_notice": "",
     "assessment_criteria_weighting": [
       {
         "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
@@ -1272,6 +1276,7 @@
     "opens": "2022-10-04 12:00:00",
     "short_name": "TT",
     "prospectus": "/prospectus_link",
+    "privacy_notice": "",
     "instructions": "Round specific instruction text",
     "support_availability": {
       "closed": "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day",
@@ -1305,6 +1310,7 @@
   "fund_store/funds/funding-service-design/rounds/summer?language=en" : {
     "assessment_deadline": "2030-03-30 12:00:00",
     "prospectus": "link",
+    "privacy_notice": "",
     "instructions": "Round specific instruction text",
     "name":"Community Ownership Fund",
     "contact_details": {
@@ -1399,6 +1405,7 @@
       },
       "title": "Round 2 Window 3",
       "prospectus": "http://google.com/search?q=r2w3",
+      "privacy_notice": "",
       "instructions": "Round specific instruction text"
     },
   "fund_store/funds/cof/rounds?language=en&use_short_name=true":
@@ -1444,6 +1451,7 @@
         },
         "title": "Round 2 Window 2",
         "prospectus": "http://google.com/search?q=r2w2",
+        "privacy_notice": "",
         "instructions": "Round specific instruction text for r2w2"
       },
       {
@@ -1487,6 +1495,7 @@
         },
         "title": "Round 2 Window 3",
         "prospectus_link": "http://google.com/search?q=r2w3",
+        "privacy_notice": "",
         "instructions": "Round specific instruction text for r2w3"
       }
     ]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,6 +8,7 @@ common_round_data = {
     "assessment_deadline": "2030-03-20 00:00:01",
     "assessment_criteria_weighting": [],
     "contact_details": {},
+    "privacy_notice": "",
     "support_availability": {},
     "prospectus": "/cof_r2w2_prospectus",
     "instructions": "Round specific instruction text",

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -15,6 +15,7 @@ default_round_fields = {
     "title": "test round title",
     "short_name": "SHORT",
     "prospectus": "",
+    "privacy_notice": "",
     "instructions": "",
     "contact_details": {"email_address": "blah@google.com"},
     "support_availability": SupportAvailability("", "", ""),


### PR DESCRIPTION
###FS-2429 Make privacy notice url dynamic in footer

### Change description
Previously, frontend footer links for Privacy notice was hardcoded url, this now has changed to retrieve the url from the fund data endpoint and redirects when visiting /privacy url. It also has a fallback of a hardcoded privacy notice url when failing to retrieve from endpoint.