### PR TITLE
FS-2826 Only showing welsh link if fund supports it

### DIFF
--- a/app/default/account_routes.py
+++ b/app/default/account_routes.py
@@ -141,6 +141,7 @@ def dashboard():
 
     fund_short_name = request.args.get("fund")
     round_short_name = request.args.get("round")
+    welsh_available = True
 
     if fund_short_name and round_short_name:
         # find and display applications with this
@@ -150,11 +151,16 @@ def dashboard():
             fund_short_name,
             round_short_name,
         )
+        fund_details = get_fund_data_by_short_name(
+            fund_short_name,
+        )
+        welsh_available = fund_details.welsh_available
         search_params = {
             "fund_id": round_details.fund_id,
             "round_id": round_details.id,
             "account_id": account_id,
         }
+
     elif fund_short_name:
         # find and display all applications across
         # this fund else return 404
@@ -167,6 +173,7 @@ def dashboard():
             "fund_id": fund_details.id,
             "account_id": account_id,
         }
+        welsh_available = fund_details.welsh_available
     else:
         # Generic all applications dashboard
         template_name = "dashboard_all.html"
@@ -184,8 +191,6 @@ def dashboard():
     current_app.logger.info(
         f"Setting up applicant dashboard for :'{account_id}'"
     )
-    # TODO will need to tell the dashboard template whether it's for a
-    # particular fund or it's the generic dashboard.
     return render_template(
         template_name,
         account_id=account_id,
@@ -193,6 +198,7 @@ def dashboard():
         show_language_column=show_language_column,
         fund_short_name=fund_short_name,
         round_short_name=round_short_name,
+        welsh_available=welsh_available,
     )
 
 

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -49,6 +49,7 @@ def index_fund_round(fund_short_name, round_short_name):
         contact_us_email_address=round_data.contact_email,
         prospectus_link=round_data.prospectus,
         instruction_text=round_data.instructions,
+        welsh_available=fund_data.welsh_available,
     )
 
 

--- a/app/models/fund.py
+++ b/app/models/fund.py
@@ -14,6 +14,7 @@ class Fund:
     short_name: str
     description: str
     title: str
+    welsh_available: bool
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/app/templates/dashboard_all.html
+++ b/app/templates/dashboard_all.html
@@ -16,7 +16,7 @@
         {% set application_count=display_data["total_applications_to_display"]%}
         {% trans %}You have started{% endtrans %}&nbsp;{% trans count=application_count%} {{application_count}} application{% pluralize %}{{application_count}} applications{% endtrans %}&nbsp;{% trans %}using this email address{% endtrans %}.
     </p>
-{{available_in_language(inset=False, warn=True)}}
+{{available_in_language(inset=False, warn=True, welsh_available=welsh_available)}}
 
 <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     {% for fund in display_data["funds"] %}

--- a/app/templates/dashboard_single_fund.html
+++ b/app/templates/dashboard_single_fund.html
@@ -21,7 +21,7 @@ Your applications
         {% trans %}You have started{% endtrans %}&nbsp;{% trans count=application_count%} {{application_count}} application{% pluralize %}{{application_count}} applications{% endtrans %}&nbsp;{% trans %}using this email address{% endtrans %}.
     </p>
 
-    {{available_in_language(inset=False, warn=True)}}
+    {{available_in_language(inset=False, warn=True, welsh_available=welsh_available)}}
 
 
     {% for fund in display_data["funds"] %}

--- a/app/templates/fund_start_page.html
+++ b/app/templates/fund_start_page.html
@@ -4,7 +4,8 @@
 {% endset %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText
     -%} {%- from "govuk_frontend_jinja/components/button/macro.html" import
-    govukButton -%} {% from "partials/available_in_language.html" import available_in_language %} {% from "partials/round_closed_warning.html" import round_closed_warning %}
+    govukButton -%} {% from "partials/available_in_language.html" import available_in_language %}
+{% from "partials/round_closed_warning.html" import round_closed_warning %}
  {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -19,7 +20,7 @@
             {% if is_past_submission_deadline %}
                 {{ round_closed_warning(fund_name, round_title, submission_deadline) }}
             {% endif %}
-            {{available_in_language(inset=True, warn=False)}}
+            {{available_in_language(inset=True, warn=False, welsh_available=welsh_available)}}
             <p class="govuk-body">
                 {{instruction_text|safe}}
             </p>

--- a/app/templates/partials/available_in_language.html
+++ b/app/templates/partials/available_in_language.html
@@ -1,13 +1,15 @@
-{% macro available_in_language(inset, warn) %}
-<p class="govuk-body {{'govuk-inset-text' if inset else ''}}">{% trans url=url_for('select_language', locale=('cy' if get_lang() == 'en' else 'en')) %} This service is also available <a href="{{ url }}" class="govuk-link">in Welsh (Cymraeg){% endtrans %}</a>.</p>
+{% macro available_in_language(inset, warn, welsh_available) %}
+  {% if welsh_available %}
+    <p class="govuk-body {{'govuk-inset-text' if inset else ''}}">{% trans url=url_for('select_language', locale=('cy' if get_lang() == 'en' else 'en')) %} This service is also available <a href="{{ url }}" class="govuk-link">in Welsh (Cymraeg){% endtrans %}</a>.</p>
 
-{% if warn %}
-<div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning</span>
-      {% trans %}You cannot change the language of an existing application.{% endtrans %}
-    </strong>
-</div>
-{% endif %}
+    {% if warn %}
+      <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            {% trans %}You cannot change the language of an existing application.{% endtrans %}
+          </strong>
+      </div>
+    {% endif %}
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
### Change description
As not all funds support welsh, we need to only show the 'avaialble in welsh' link if the fund supports it.

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Pull this branch, plus the below branches of other repos and run in docker-runner. 
2. Make sure COF and NS data are in the DB. 
3. Login to the service and go to the 'View all applications' link at the top. 
5. Scroll down to Night Shelter and click 'view applications from all rounds/windows'
6. There should be no 'This service is also available in Welsh' link.
7. Go back to list of all applications.
8. Scroll to COF and click 'view applications from all rounds/windows'
9. There should be a 'this service is also available in welsh' link.

This logic also applies to the fund start page:
http://localhost:3008/funding-round/cof/r2w3 - should show the welsh link
http://localhost:3008/funding-round/ns/r2 - should not show the welsh link

Linked branches:
- https://github.com/communitiesuk/funding-service-design-fund-store/tree/fs-2815-ns-config
- https://github.com/communitiesuk/funding-service-design-application-store/tree/fs-2826-welsh-optional
- https://github.com/communitiesuk/funding-service-design-frontend/tree/fs-2826-welsh-optional

### Screenshots of UI changes (if applicable)
N/A