### PR TITLE
Fs 2827 dynamic feedback link

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from app.default.data import get_default_fund_and_round
 from app.default.data import get_default_round_for_fund
 from app.default.data import get_fund_data
 from app.default.data import get_fund_data_by_short_name
@@ -139,12 +138,7 @@ def create_app() -> Flask:
         elif request.args.get("fund"):
             fund = get_fund_data_by_short_name(request.args.get("fund"))
         else:
-            (fund_short_name, _) = get_default_fund_and_round()
-            fund = get_fund_data_by_short_name(fund_short_name)
-            current_app.logger.warn(
-                "Couldn't found any fund in the requests. Using"
-                f" {fund_short_name} as default fund!"
-            )
+            current_app.logger.warn("Couldn't found any fund in the request")
         return fund
 
     def find_round_in_request(fund):

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -138,7 +138,7 @@ def create_app() -> Flask:
         elif request.args.get("fund"):
             fund = get_fund_data_by_short_name(request.args.get("fund"))
         else:
-            current_app.logger.warn("Couldn't found any fund in the request")
+            current_app.logger.warn("Couldn't find any fund in the request")
         return fund
 
     def find_round_in_request(fund):
@@ -152,8 +152,8 @@ def create_app() -> Flask:
         else:
             round = get_default_round_for_fund(fund.short_name)
             current_app.logger.warn(
-                "Couldn't found any fund in the requests. Using"
-                f" {round.short_name} as default fund!"
+                "Couldn't find round in request. Using"
+                f" {round.short_name} as default for fund {fund.short_name}"
             )
         return round
 

--- a/app/create_app.py
+++ b/app/create_app.py
@@ -199,6 +199,11 @@ def create_app() -> Flask:
                             fund=fund.short_name,
                             round=round.short_name,
                         ),
+                        feedback_url=url_for(
+                            "content_routes.feedback",
+                            fund=fund.short_name,
+                            round=round.short_name,
+                        ),
                     )
         except Exception as e:  # noqa
             current_app.logger.warn(
@@ -209,6 +214,7 @@ def create_app() -> Flask:
         return dict(
             contact_us_url=url_for("content_routes.contact_us"),
             privacy_url=url_for("content_routes.privacy"),
+            feedback_url=url_for("content_routes.feedback"),
         )
 
     @flask_app.before_request

--- a/app/default/account_routes.py
+++ b/app/default/account_routes.py
@@ -199,6 +199,8 @@ def dashboard():
 @account_bp.route("/account/new", methods=["POST"])
 @login_required
 def new():
+    fund_short_name = request.args.get("fund")
+    round_short_name = request.args.get("round")
     account_id = g.account_id
     new_application = requests.post(
         url=f"{Config.APPLICATION_STORE_API_HOST}/applications",
@@ -222,6 +224,8 @@ def new():
     return redirect(
         url_for(
             "application_routes.tasklist",
+            fund=fund_short_name,
+            round=round_short_name,
             application_id=new_application.json().get("id"),
         )
     )

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -1,7 +1,7 @@
-from app.default.data import get_default_fund_and_round
 from app.default.data import get_fund_data_by_short_name
 from app.default.data import get_round_data_by_short_names
 from app.default.data import get_round_data_fail_gracefully
+from app.models.round import Round
 from flask import abort
 from flask import Blueprint
 from flask import current_app
@@ -54,16 +54,37 @@ def contact_us():
         f"Contact us page loaded for fund {fund_short_name} round"
         f" {round_short_name}."
     )
-    if not (fund_short_name and round_short_name):
-        (fund_short_name, round_short_name) = get_default_fund_and_round()
-    round_data = get_round_data_fail_gracefully(
-        fund_short_name, round_short_name, True
-    )
-    fund_data = get_fund_data_by_short_name(fund_short_name)
+    if round_short_name and fund_short_name:
+        round_data = get_round_data_fail_gracefully(
+            fund_short_name, round_short_name, True
+        )
+        fund_data = get_fund_data_by_short_name(fund_short_name)
+        fund_name = fund_data.name
+    else:
+        round_data = Round(
+            id="",
+            assessment_deadline="",
+            deadline="",
+            fund_id="",
+            opens="",
+            title="",
+            short_name="",
+            prospectus="",
+            privacy_notice="",
+            instructions="",
+            contact_email="",
+            contact_phone="",
+            contact_textphone="",
+            support_days="",
+            support_times="",
+            feedback_link="",
+            project_name_field_id="",
+        )
+        fund_name = ""
     return render_template(
         "contact_us.html",
         round_data=round_data,
-        fund_name=fund_data.name,
+        fund_name=fund_name,
     )
 
 

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -48,9 +48,12 @@ def cof_r2w2_all_questions_redirect():
 
 @content_bp.route("/contact_us", methods=["GET"])
 def contact_us():
-    current_app.logger.info("Contact us page loaded.")
     fund_short_name = request.args.get("fund")
     round_short_name = request.args.get("round")
+    current_app.logger.info(
+        f"Contact us page loaded for fund {fund_short_name} round"
+        f" {round_short_name}."
+    )
     if not (fund_short_name and round_short_name):
         (fund_short_name, round_short_name) = get_default_fund_and_round()
     round_data = get_round_data_fail_gracefully(
@@ -91,4 +94,35 @@ def privacy():
     )
     return redirect(
         "https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice"  # noqa
+    )
+
+
+@content_bp.route("/feedback", methods=["GET"])
+def feedback():
+    fund_short_name = request.args.get("fund")
+    round_short_name = request.args.get("round")
+    current_app.logger.info(
+        f"Feedback page loading for fund {fund_short_name} round"
+        f" {round_short_name}."
+    )
+    if fund_short_name and round_short_name:
+        round_data = get_round_data_by_short_names(
+            fund_short_name, round_short_name
+        )
+        feedback_url = getattr(round_data, "feedback_link", None)
+
+        if feedback_url:
+            current_app.logger.debug("Feedback link configured for fund")
+            return redirect(feedback_url)
+
+    current_app.logger.warning(
+        f"No feedback url configured for round ({fund_short_name} -"
+        f" {round_short_name}). Redirecting..."
+    )
+    return redirect(
+        url_for(
+            "content_routes.contact_us",
+            fund=fund_short_name,
+            round=round_short_name,
+        )
     )

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -378,29 +378,3 @@ def get_default_round_for_fund(fund_short_name: str) -> Round:
     except Exception as e:
         current_app.log_exception(e)
         return None
-
-
-def get_default_fund_and_round() -> tuple[str, str]:
-    """Get the latest opened or closed round as default round."""
-    all_funds = get_all_funds()
-
-    if all_funds:
-        if len(all_funds) == 1:
-            default_fund = all_funds[0]
-            default_round = get_default_round_for_fund(
-                default_fund["short_name"]
-            )
-        else:
-            all_rounds = [
-                get_default_round_for_fund(fund["short_name"])
-                for fund in all_funds
-            ]
-            all_rounds = [round for round in all_rounds if round]
-            if not all_rounds:
-                return (all_funds[0]["short_name"], None)
-            default_round = get_latest_open_or_closed_round(all_rounds)
-            default_fund = get_fund_data(default_round.fund_id)
-
-        return (default_fund["short_name"], default_round.short_name)
-    else:
-        raise ValueError("No Funds and rounds are found!")

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -265,27 +265,27 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
         current_app.logger.error(
             f"Call to Fund Store failed GET {round_request_url}"
         )
-        # return valid Round object with no values so we know we've
-        # failed and can handle in templates appropriately
-        return Round(
-            id="",
-            assessment_deadline="",
-            deadline="",
-            fund_id="",
-            opens="",
-            title="",
-            short_name="",
-            prospectus="",
-            privacy_notice="",
-            instructions="",
-            contact_email="",
-            contact_phone="",
-            contact_textphone="",
-            support_days="",
-            support_times="",
-            feedback_link="",
-            project_name_field_id="",
-        )
+    # return valid Round object with no values so we know we've
+    # failed and can handle in templates appropriately
+    return Round(
+        id="",
+        assessment_deadline="",
+        deadline="",
+        fund_id="",
+        opens="",
+        title="",
+        short_name="",
+        prospectus="",
+        privacy_notice="",
+        instructions="",
+        contact_email="",
+        contact_phone="",
+        contact_textphone="",
+        support_days="",
+        support_times="",
+        feedback_link="",
+        project_name_field_id="",
+    )
 
 
 def get_account(email: str = None, account_id: str = None) -> Account | None:

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -283,6 +283,8 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
             contact_textphone="",
             support_days="",
             support_times="",
+            feedback_link="",
+            project_name_field_id="",
         )
 
 

--- a/app/models/round.py
+++ b/app/models/round.py
@@ -21,6 +21,8 @@ class Round:
     contact_textphone: str
     support_days: str
     support_times: str
+    feedback_link: str
+    project_name_field_id: str
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/app/templates/contact_us.html
+++ b/app/templates/contact_us.html
@@ -8,8 +8,11 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
-            <p class="govuk-body">{% trans %}Contact the{% endtrans %} {{fund_name}} {% trans %}if you have any questions.{% endtrans %}</p>
-
+            {% if fund_name %}
+                <p class="govuk-body">{% trans %}Contact the{% endtrans %} {{fund_name}} {% trans %}if you have any questions.{% endtrans %}</p>
+            {% else %}
+                <p class="govuk-body">{% trans %}Contact us if you have any questions.{% endtrans %}</p>
+            {% endif %}
             {% if round_data.contact_email or round_data.contact_phone or round_data.support_days or round_data.support_times %}
                 {{ contact_details(
                             round_data.contact_email,

--- a/app/templates/dashboard_single_fund.html
+++ b/app/templates/dashboard_single_fund.html
@@ -34,9 +34,9 @@ Your applications
                 {% if round["is_past_submission_deadline"] %}
                     {{ round_closed_warning(fund["fund_data"]["name"], round["round_details"]["title"], round["round_details"]["deadline"]) }}
                 {% endif %}
-                    {{ applications_table(round["applications"], round["is_past_submission_deadline"], show_language_column) }}
+                    {{ applications_table(round["applications"], round["is_past_submission_deadline"], show_language_column, fund_short_name, round_short_name) }}
                 {% if not round["is_past_submission_deadline"] %}
-                    {{ startApplicationButton(form, url_for('account_routes.new'), fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"], existing_applications_count=round["applications"]|count) }}
+                    {{ startApplicationButton(form, url_for('account_routes.new', fund=fund_short_name, round=round_short_name), fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"], existing_applications_count=round["applications"]|count) }}
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -49,6 +49,6 @@
         'tag': {
             'text': gettext('beta')
         },
-        'html': '{}<a href="https://forms.office.com/Pages/ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqFJBHpeOL2tNnpiwpdL2iElUREIySU9OWTU4R0RTNjhBUDE1Q1VYVFBEMi4u" class="govuk-link">{}</a>{}'.format(gettext('This is a new service - your '), gettext('feedback'), gettext(' will help us to improve it.'))
+        'html': '{}<a href="{}" class="govuk-link">{}</a>{}'.format(gettext('This is a new service - your '), feedback_url, gettext('feedback'), gettext(' will help us to improve it.'))
     })}}
 </div>

--- a/app/templates/partials/applications_table.html
+++ b/app/templates/partials/applications_table.html
@@ -2,7 +2,7 @@
 {%- from "govuk_frontend_jinja/components/tag/macro.html" import govukTag -%}
 {%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable -%}
 
-{% macro applications_table(applications, is_past_submission_deadline, show_language_column) %}
+{% macro applications_table(applications, is_past_submission_deadline, show_language_column, fund_short_name, round_short_name) %}
 
 	{% set ns = namespace(rows = []) %}
 	{% for application in applications %}

--- a/tests/api_data/endpoint_data.json
+++ b/tests/api_data/endpoint_data.json
@@ -38,7 +38,9 @@
       "support_days": "Mon-Fri",
       "prospectus": "/cof_r2w2_prospectus",
       "privacy_notice": "",
-      "instructions": "Round specific instruction text"
+      "instructions": "Round specific instruction text",
+      "project_name_field_id": "",
+      "feedback_link": ""
     },
     {
       "opens": "2022-09-01T00:00:01",
@@ -55,7 +57,9 @@
       "support_days": "Mon-Fri",
       "prospectus": "/fsd_r2w3_prospectus",
       "privacy_notice": "",
-      "instructions": "Round specific instruction text"
+      "instructions": "Round specific instruction text",
+      "project_name_field_id": "",
+      "feedback_link": ""
     }
   ],
   "fund_store/funds/fsd/rounds?language=en&use_short_name=true": [
@@ -74,7 +78,9 @@
       "support_days": "Mon-Fri",
       "prospectus": "/cof_r2w2_prospectus",
       "privacy_notice": "",
-      "instructions": "Round specific instruction text"
+      "instructions": "Round specific instruction text",
+      "project_name_field_id": "",
+      "feedback_link": ""
     },
     {
       "opens": "2022-09-01T00:00:01",
@@ -91,7 +97,9 @@
       "support_days": "Mon-Fri",
       "prospectus": "/fsd_r2w3_prospectus",
       "privacy_notice": "",
-      "instructions": "Round specific instruction text"
+      "instructions": "Round specific instruction text",
+      "project_name_field_id": "",
+      "feedback_link": ""
     }
   ],
    "fund_store/funds/47aef2f5-3fcb-4d45-acb5-f0152b5f03c4?language=en": {
@@ -117,7 +125,9 @@
       "contact_textphone": "123456789",
       "support_times": "9-5",
       "support_days": "Mon-Fri",
-      "privacy_notice": ""
+      "privacy_notice": "",
+      "project_name_field_id": "",
+      "feedback_link": ""
     },
     {
       "assessment_deadline": "2023-05-05 12:00:00",
@@ -134,7 +144,9 @@
       "contact_textphone": "123456789",
       "support_times": "9-5",
       "support_days": "Mon-Fri",
-      "privacy_notice": ""
+      "privacy_notice": "",
+      "project_name_field_id": "",
+      "feedback_link": ""
     }
   ],
   "fund_store/funds/47aef2f5-3fcb-4d45-acb5-f0152b5f03c4/rounds/c603d114-5364-4474-a0c4-c41cbf4d3bbd?language=en": {
@@ -152,7 +164,9 @@
     "contact_phone": "123456789",
     "contact_textphone": "123456789",
     "support_times": "9-5",
-    "support_days": "Mon-Fri"
+    "support_days": "Mon-Fri",
+    "project_name_field_id": "",
+    "feedback_link": ""
   },
   "fund_store/funds/47aef2f5-3fcb-4d45-acb5-f0152b5f03c4/rounds/5cf439bf-ef6f-431e-92c5-a1d90a4dd32f?language=en": {
     "id": "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f",
@@ -168,7 +182,9 @@
     "contact_phone": "123456789",
     "contact_textphone": "123456789",
     "support_times": "9-5",
-    "support_days": "Mon-Fri"
+    "support_days": "Mon-Fri",
+    "project_name_field_id": "",
+    "feedback_link": ""
   },
   "application_store/applications/test_id": {
     "id": "test_id",
@@ -1305,7 +1321,9 @@
     "contact_phone": "123456789",
     "contact_textphone": "123456789",
     "support_times": "9-5",
-    "support_days": "Mon-Fri"
+    "support_days": "Mon-Fri",
+    "project_name_field_id": "",
+    "feedback_link": ""
   },
   "fund_store/funds/funding-service-design/rounds/summer?language=en" : {
     "assessment_deadline": "2030-03-30 12:00:00",
@@ -1323,7 +1341,9 @@
     "contact_phone": "123456789",
     "contact_textphone": "123456789",
     "support_times": "9-5",
-    "support_days": "Mon-Fri"
+    "support_days": "Mon-Fri",
+    "project_name_field_id": "",
+    "feedback_link": ""
   },
   "account_store/accounts?account_id=test-user": {
         "account_id": "test-user",
@@ -1353,7 +1373,8 @@
       "contact_textphone": "123456789",
       "support_times": "9-5",
       "support_days": "Mon-Fri",
-      "privacy_notice": ""
+      "project_name_field_id": "",
+      "feedback_link": ""
     },
   "fund_store/funds/cof/rounds?language=en&use_short_name=true":
     [
@@ -1372,7 +1393,9 @@
         "contact_textphone": "123456789",
         "support_times": "9-5",
         "support_days": "Mon-Fri",
-        "privacy_notice": ""
+        "privacy_notice": "",
+        "project_name_field_id": "",
+        "feedback_link": ""
       },
       {
         "assessment_deadline": "2023-05-05 12:00:00",
@@ -1389,7 +1412,9 @@
         "contact_textphone": "123456789",
         "support_times": "9-5",
         "support_days": "Mon-Fri",
-        "privacy_notice": ""
+        "privacy_notice": "",
+        "project_name_field_id": "",
+        "feedback_link": ""
       }
     ],
   "fund_store/funds/funding-service-design/rounds/summer/sections/application": [

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -92,6 +92,8 @@ TEST_ROUNDS_DATA = [
             "short_name": "r2w2",
             "title": "closed_round",
             "deadline": "2023-01-01T00:00:01",
+            "project_name_field_id": "",
+            "feedback_link": "",
         }
     ),
     Round.from_dict(
@@ -102,6 +104,8 @@ TEST_ROUNDS_DATA = [
             "short_name": "r2w3",
             "title": "open_round",
             "deadline": "2050-01-01T00:00:01",
+            "project_name_field_id": "",
+            "feedback_link": "",
         }
     ),
     Round.from_dict(
@@ -112,6 +116,8 @@ TEST_ROUNDS_DATA = [
             "short_name": "r1",
             "title": "closed_round",
             "deadline": "2023-01-01T00:00:01",
+            "project_name_field_id": "",
+            "feedback_link": "",
         }
     ),
     Round.from_dict(
@@ -122,6 +128,8 @@ TEST_ROUNDS_DATA = [
             "short_name": "r2",
             "title": "open_round",
             "deadline": "2050-01-01T00:00:01",
+            "project_name_field_id": "",
+            "feedback_link": "",
         }
     ),
 ]

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -20,6 +20,8 @@ default_round_fields = {
     "contact_textphone": "123456789",
     "support_times": "9-5",
     "support_days": "Mon-Fri",
+    "project_name_field_id": "",
+    "feedback_link": "",
 }
 
 


### PR DESCRIPTION
### Change description
Feedback URL is now dynamic - loaded from the round data. If it's not present in the round, or the round is not supplied, redirects to contact us.
Removed function to determine default fund and round as we no longer need this now we are multi fund - instead of falling back to a default we return a 404 which displays default contact details.

- [x] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Navigate to the main page for different funds - the feedback link in the header should contain the fund and round short codes as querystring params.

Relies on latest night shelter branch for fund-store as this contains the db field for the feedback url.


