### PR TITLE
BAU: Removed visual index print

### DIFF
--- a/app/templates/partials/tasklist_section.html
+++ b/app/templates/partials/tasklist_section.html
@@ -1,7 +1,7 @@
 {% macro tasklist_section(section_name, section_data, weighting, application_meta_data, application_status, index) %}
 <li>
     <h2 class="app-task-list__section">
-      <span class="app-task-list__section-number">{{index}}. </span> {{section_name}}
+      {{section_name}}
     </h2>
     {% if weighting %}
     <p class="govuk-body">{% trans %}This section is worth{% endtrans %} <b>{{weighting}}</b>% {% trans %}of the assessment criteria{% endtrans %}.</p>


### PR DESCRIPTION
Remove index printing in favour of configured section names in the fund store
Supports new project-name-ns section, see: https://github.com/communitiesuk/funding-service-design-fund-store/pull/85