### PR TITLE
bau-return-404-index

### DIFF
--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -19,8 +19,7 @@ def index():
     """
     Redirects from the old landing page to the new one at /cof/r2w3
     """
-    current_app.logger.info("Redirecting from index to /cof/r2w3")
-    return redirect("funding-round/cof/r2w3")
+    return abort(404)
 
 
 @default_bp.route("/funding-round/<fund_short_name>/<round_short_name>")

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -50,8 +50,7 @@ def mock_get_round(mocker):
 
 def test_old_index_redirect(client):
     result = client.get("/", follow_redirects=False)
-    assert result.status_code == 302
-    assert result.location == "funding-round/cof/r2w3"
+    assert result.status_code == 404
 
 
 def test_start_page_unknown_fund(client, mocker):


### PR DESCRIPTION
Return 404 when a user tries to access the service without using a link provided i.e. no fund and round params.