### PR TITLE
Reverting default service name to Access Funding

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -133,9 +133,11 @@ def create_app() -> Flask:
         ]:
             fund = get_fund_data_by_short_name(fund_short_name)
         elif request.view_args.get("fund_id"):
-            fund = get_fund_data(request.view_args.get("fund_id"), True)
+            fund = get_fund_data(
+                request.view_args.get("fund_id"), as_dict=True
+            )
         elif request.args.get("fund_id"):
-            fund = get_fund_data(request.args.get("fund_id"), True)
+            fund = get_fund_data(request.args.get("fund_id"), as_dict=True)
         elif request.args.get("fund"):
             fund = get_fund_data_by_short_name(request.args.get("fund"))
         else:
@@ -188,9 +190,7 @@ def create_app() -> Flask:
         if fund:
             service_title = gettext("Apply for") + " " + fund.title
         else:
-            service_title = gettext(
-                "Apply for funding to save an asset in your community"
-            )
+            service_title = gettext("Access Funding")
         return dict(service_title=service_title)
 
     @flask_app.context_processor

--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -285,6 +285,9 @@ def submit_application():
         language=application.language,
         as_dict=True,
     )
+    round_data = get_round_data(
+        application.fund_id, application.round_id, as_dict=False
+    )
     submitted = format_payload_and_submit_application(application_id)
 
     application_id = submitted.get("id")
@@ -297,6 +300,8 @@ def submit_application():
             application_reference=application_reference,
             application_email=application_email,
             fund_name=fund_data.name,
+            fund_short_name=fund_data.short_name,
+            round_short_name=round_data.short_name,
         )
 
 

--- a/app/templates/application_submitted.html
+++ b/app/templates/application_submitted.html
@@ -30,7 +30,7 @@ import govukButton -%}
             <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqFJBHpeOL2tNnpiwpdL2iElUREIySU9OWTU4R0RTNjhBUDE1Q1VYVFBEMi4u" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
           </p>
 
-          <a href="{{url_for('account_routes.dashboard')}}" >
+          <a href="{{url_for('account_routes.dashboard', fund_id=fund_id, round_id=round_id)}}" >
             <p class="govuk-body">Return to your applications page.</p>
           </a>
         </div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -59,7 +59,7 @@ fund_args = {
 short_name_fund = Fund(**fund_args, title="Test Fund by short name")
 id_fund = Fund(**fund_args, title="Test Fund by ID")
 
-default_service_title = "Apply for funding to save an asset in your community"
+default_service_title = "Access Funding"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Change description
When fixing another ticket I noticed we have a default service name of COF, but it shouldn't be fund-specific.

- [x] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Navigate to a page without any fund or round context, and the service name should be access funding
eg http://localhost:3008/contact_us


### Screenshots of UI changes (if applicable)
![Screenshot 2023-06-06 at 14 29 57](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/5fe079d6-af36-4e51-9cfe-b4b6278e704d)
