### PR TITLE
implement fix to prevent flask_babel rebasing the datetime object

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -13,7 +13,9 @@ def datetime_format_short_month(value: datetime) -> str:
     if value:
         formatted_date = format_datetime(value, format="dd MMM yyyy ")
         formatted_date += gettext("at")
-        formatted_date += format_datetime(value, format=" HH:mm")
+        formatted_date += format_datetime(
+            value, format=" HH:mm ", rebase=False
+        )
         formatted_date += format_datetime(value, "a").lower()
         return formatted_date
     else:

--- a/app/filters.py
+++ b/app/filters.py
@@ -13,9 +13,7 @@ def datetime_format_short_month(value: datetime) -> str:
     if value:
         formatted_date = format_datetime(value, format="dd MMM yyyy ")
         formatted_date += gettext("at")
-        formatted_date += format_datetime(
-            value, format=" HH:mm ", rebase=False
-        )
+        formatted_date += format_datetime(value, format=" HH:mm", rebase=False)
         formatted_date += format_datetime(value, "a").lower()
         return formatted_date
     else:


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2916


### Change description
Fix, a flask_babel filter is rebasing the time by default and therefore removing the BST time from the datetime object (and showing application last edited times as an hour behind actual), this has been changed so that it does not happen by default.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
