### PR TITLE
Updating param names for url

### DIFF
--- a/app/templates/application_submitted.html
+++ b/app/templates/application_submitted.html
@@ -30,7 +30,7 @@ import govukButton -%}
             <a href={{feedback_url}} class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
           </p>
 
-          <a href="{{url_for('account_routes.dashboard', fund_id=fund_id, round_id=round_id)}}" >
+          <a href="{{url_for('account_routes.dashboard', fund=fund_short_name, round=round_short_name)}}" >
             <p class="govuk-body">Return to your applications page.</p>
           </a>
         </div>


### PR DESCRIPTION
### Change description
FS-2991 - the param names for generating the url for the dashboard were incorrect, updated them and now you get sent to the fund dashboard.

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Submit an application, check the 'return to your applications' link takes you to the fund-specific dashboard


### Screenshots of UI changes (if applicable)
n/a