### PR TITLE
Remove feedback text from beta banner

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -49,6 +49,6 @@
         'tag': {
             'text': gettext('beta')
         },
-        'html': '{}<a href="{}" class="govuk-link">{}</a>{}'.format(gettext('This is a new service - your '), feedback_url, gettext('feedback'), gettext(' will help us to improve it.'))
+        'html': gettext('This is a new service.')
     })}}
 </div>


### PR DESCRIPTION
### Change description
FS-3348 removing feedback link from text in beta banner


### How to test
Navigate to the frontend and view the beta banner


### Screenshots of UI changes (if applicable)
![Screenshot 2023-08-23 at 14 45 01](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/5f6d88f6-a43d-4b09-aca3-7e51afa0e08f)
