### PR TITLE
FS-3387 - Removing duplicate fields

### DIFF
--- a/app/templates/end_of_application_feedback_page_1.html
+++ b/app/templates/end_of_application_feedback_page_1.html
@@ -20,8 +20,6 @@
 
             <form class="form" method="post">
                 {{ form.hidden_tag() }}
-                {{ form.csrf_token }}
-                {{ form.application_id() }}
 
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">

--- a/app/templates/end_of_application_feedback_page_2.html
+++ b/app/templates/end_of_application_feedback_page_2.html
@@ -20,8 +20,6 @@
 
             <form class="form" method="post">
                 {{ form.hidden_tag() }}
-                {{ form.csrf_token }}
-                {{ form.application_id() }}
 
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">

--- a/app/templates/end_of_application_feedback_page_3.html
+++ b/app/templates/end_of_application_feedback_page_3.html
@@ -20,8 +20,6 @@
 
             <form method="post">
                 {{ form.hidden_tag() }}
-                {{ form.csrf_token }}
-                {{ form.application_id() }}
 
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">

--- a/app/templates/end_of_application_feedback_page_4.html
+++ b/app/templates/end_of_application_feedback_page_4.html
@@ -20,8 +20,6 @@
 
             <form method="post">
                 {{ form.hidden_tag() }}
-                {{ form.csrf_token }}
-                {{ form.application_id() }}
 
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">

--- a/app/templates/feedback_generic_survey.html
+++ b/app/templates/feedback_generic_survey.html
@@ -13,7 +13,6 @@
 
             <form action="#" class="form" method="post">
                 {{ form.hidden_tag() }}
-                {{ form.application_id() }}
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">


### PR DESCRIPTION
### Change description
Remove calls to render hidden fields for specific data items as the existing call to `form.hidden_tag()` already does this. Thereby removed duplicate fields.


### How to test
Navigate to feedback form and use dev tools to view the hidden fields - as per screenshot below. No visible UI chagnes to users


![Screenshot 2023-09-06 at 14 57 30](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/896fbfc2-7471-44a5-8aff-3d85586d77ec)
