### PR TITLE
fs-3432 added label element

### DIFF
--- a/app/templates/end_of_application_feedback_page_4.html
+++ b/app/templates/end_of_application_feedback_page_4.html
@@ -33,9 +33,9 @@
                             This includes time spent attending meetings, preparing documents and business cases, doing
                             research and collating answers, from both paid and volunteer resources.
                         </div>
-                        <div id="" class="govuk-label govuk-label--s">
+                        <label for="hours-spent" class="govuk-label govuk-label--s">
                             {{ form.hours_spent.label }}
-                        </div>
+                        </label>
                         <div class="govuk-form-group">
                             {{ form.hours_spent(class="govuk-input", id="hours-spent") }}
                         </div>


### PR DESCRIPTION
### Change description
Minor change to change a `div` to a `label` and fix a critical accessibility bug


### How to test
Launch feedback survey, navigate to page 4 and check that the text for the hours spent field is a label element

![Screenshot 2023-09-07 at 11 25 40](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/6459779a-bc5b-4f6a-9672-ebe644d261b4)
