### PR TITLE
FS-3441 added yelp hook for secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,10 @@ repos:
 #     rev: v1.0.5
 #     hooks:
 #     -   id: python-bandit-vulnerability-check
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  -   id: detect-secrets
+      args: ['--disable-plugin', 'HexHighEntropyString',
+        '--disable-plugin', 'Base64HighEntropyString']
+      exclude: tests/keys/rsa256

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -88,6 +88,6 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -7,11 +7,11 @@ applications:
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
   # TODO: Remove gids.dev domain if fundingservice.co.uk domain DNS gets restored.
   env:
-    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.dev.gids.dev
+    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
     ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-dev.london.cloudapps.digital
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-dev.london.cloudapps.digital
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-dev.apps.internal:8080
-    FORMS_SERVICE_PUBLIC_HOST: https://fsd:fsd@forms.dev.gids.dev
+    FORMS_SERVICE_PUBLIC_HOST: https://fsd:fsd@forms.dev.gids.dev  # pragma: allowlist secret
     FUND_STORE_API_HOST: https://funding-service-design-fund-store-dev.london.cloudapps.digital
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -7,11 +7,11 @@ applications:
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
    # TODO: Remove gids.dev domain if fundingservice.co.uk domain DNS gets restored.
   env:
-    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.test.gids.dev
+    AUTHENTICATOR_HOST: https://fsd:fsd@authenticator2.test.gids.dev  # pragma: allowlist secret
     ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-test.london.cloudapps.digital
     APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-test.london.cloudapps.digital
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-test.apps.internal:8080
-    FORMS_SERVICE_PUBLIC_HOST: https://fsd:fsd@forms.test.gids.dev
+    FORMS_SERVICE_PUBLIC_HOST: https://fsd:fsd@forms.test.gids.dev  # pragma: allowlist secret
     FUND_STORE_API_HOST: https://funding-service-design-fund-store-test.london.cloudapps.digital
     RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
     FORMS_SERVICE_PRIVATE_HOST: ((FORMS_SERVICE_PRIVATE_HOST))


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugins `HexHighEntropyString` & `Base64HighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API key/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 