### PR TITLE
Fs 3356 mark as complete

### DIFF
--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -19,6 +19,7 @@ from app.forms.feedback_forms import (
 )
 from app.helpers import format_rehydrate_payload
 from app.helpers import get_feedback_survey_data
+from app.helpers import get_round
 from app.helpers import get_section_feedback_data
 from app.helpers import get_token_to_return_to_application
 from app.models.statuses import get_formatted
@@ -287,11 +288,18 @@ def continue_application(application_id):
     )
 
     application = get_application_data(application_id)
+    round = get_round(
+        fund_id=application.fund_id, round_id=application.round_id
+    )
 
     form_data = application.get_form_data(application, form_name)
 
     rehydrate_payload = format_rehydrate_payload(
-        form_data, application_id, return_url, form_name
+        form_data,
+        application_id,
+        return_url,
+        form_name,
+        round.mark_as_complete_enabled,
     )
 
     rehydration_token = get_token_to_return_to_application(

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -111,7 +111,8 @@ def format_rehydrate_payload(
 
     current_app.logger.info(
         "constructing session rehydration payload for application"
-        f" id:{application_id}."
+        f" id:{application_id}, markAsCompleteEnabled:"
+        f" {markAsCompleteEnabled}."
     )
     formatted_data = {}
     callback_url = Config.UPDATE_APPLICATION_FORM_ENDPOINT

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -14,6 +14,7 @@ from app.default.data import get_round_data_by_short_names
 from app.default.data import get_survey_data
 from app.default.data import get_ttl_hash
 from app.models.fund import Fund
+from app.models.round import Round
 from config import Config
 from flask import current_app
 from flask import request
@@ -65,7 +66,13 @@ def extract_subset_of_data_from_application(
     return application_data[data_subset_name]
 
 
-def format_rehydrate_payload(form_data, application_id, returnUrl, form_name):
+def format_rehydrate_payload(
+    form_data,
+    application_id,
+    returnUrl,
+    form_name,
+    markAsCompleteEnabled: bool,
+):
     """
     Returns information in a JSON format that provides the
     POST body for the utilisation of the save and return
@@ -113,6 +120,7 @@ def format_rehydrate_payload(form_data, application_id, returnUrl, form_name):
         "callbackUrl": callback_url,
         "customText": {"nextSteps": "Form Submitted"},
         "returnUrl": returnUrl,
+        "markAsCompleteComponent": markAsCompleteEnabled,
     }
     formatted_data["questions"] = extract_subset_of_data_from_application(
         form_data, "questions"
@@ -235,13 +243,20 @@ def get_fund(
 
 def get_round(
     fund: Fund = None,
+    fund_id=None,
     fund_short_name: str = None,
     round_id: str = None,
     round_short_name: str = None,
-):
+) -> Round:
     if fund_short_name:
         fund = get_fund_data_by_short_name(
             fund_short_name, ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME)
+        )
+    elif fund_id:
+        fund = get_fund_data(
+            fund_id=fund_id,
+            as_dict=False,
+            ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
         )
     if not fund:
         return None

--- a/app/models/round.py
+++ b/app/models/round.py
@@ -25,6 +25,7 @@ class Round:
     project_name_field_id: str
     application_guidance: str
     requires_feedback: bool = False
+    mark_as_complete_enabled: bool = False
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -24,4 +24,4 @@ class DevelopmentConfig(DefaultConfig):
             RSA256_PUBLIC_KEY = public_key_file.read()
 
     # LRU cache settings
-    LRU_CACHE_TIME = 300  # in seconds
+    LRU_CACHE_TIME = 30  # in seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,10 @@ def mock_get_fund_round(mocker):
         return_value=TEST_ROUNDS_DATA[0],
     )
     mocker.patch(
+        "app.default.application_routes.get_round",
+        return_value=TEST_ROUNDS_DATA[0],
+    )
+    mocker.patch(
         "app.default.application_routes.get_fund_data",
         return_value=Fund.from_dict(TEST_FUNDS_DATA[0]),
     )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -17,6 +17,7 @@ common_round_data = {
     "project_name_field_id": "",
     "feedback_link": "http://feedback.com",
     "application_guidance": "",
+    "mark_as_complete_enabled": False,
 }
 common_application_data = {
     "account_id": "test-user",


### PR DESCRIPTION
Adding support for 'mark this section as complete' at the end of each section - updated function that creates the form reghydration payload for the form-runner to pass in whether or not this round uses the 'mark as complete' functionality.

Goes with the following PRs:
https://github.com/communitiesuk/digital-form-builder/pull/309
https://github.com/communitiesuk/funding-service-design-application-store/pull/228
https://github.com/communitiesuk/funding-service-design-fund-store/pull/125


### Change description
_A brief description of the pull request_

- [x] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Update a round to have `markAsCompleteEnabled=true`
Start an application in that round
Complete a section and you should see the 'mark this section as complete' radio fields on the summary
Select 'No'
Back on the tasklist the section should show as 'In PRogress'
Go through the section again and choose 'yes' on the summary page
That section should show as complete in the tasklist


### Screenshots of UI changes (if applicable)
![Screenshot 2023-09-25 at 15 39 01](https://github.com/communitiesuk/funding-service-design-application-store/assets/1729216/f9037857-081f-43cc-b03f-0627fab90bb5)