### PR TITLE
Remove Unneeded Private Key definition

### DIFF
--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -8,10 +8,6 @@ from fsd_utils import configclass
 
 @configclass
 class TestConfig(DefaultConfig):
-
-    RSA256_PRIVATE_KEY = base64.b64decode(
-        environ.get("RSA256_PRIVATE_KEY_BASE64")
-    ).decode()
     RSA256_PUBLIC_KEY = base64.b64decode(
         environ.get("RSA256_PUBLIC_KEY_BASE64")
     ).decode()


### PR DESCRIPTION
### Change description

* Private key is no longer passed via environment, so causes an error on deploy
* However, private key is not even needed in this service

+ref: BAU-3317
+semver: minor

- [ N/A ] Unit tests and other appropriate tests added or updated
- [ N/A ] README and other documentation has been updated / added (if needed)
- [ X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
