### PR TITLE
Replaced notification with frontend

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Inject replacement image into manifest
       run: |
-        yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-frontend:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}"'  copilot/fsd-notification/manifest.yml
+        yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-frontend:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}"'  copilot/fsd-frontend/manifest.yml
 
     - name: Copilot deploy dev
       id: dev_build
@@ -118,7 +118,7 @@ jobs:
 
     - name: Inject replacement image into manifest
       run: |
-        yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-frontend:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}"'  copilot/fsd-notification/manifest.yml
+        yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-frontend:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}"'  copilot/fsd-frontend/manifest.yml
 
     - name: Copilot deploy test
       id: test_build


### PR DESCRIPTION
### Change description

References to notification in the manifest replacement section should have been frontend

- [ N/A ] Unit tests and other appropriate tests added or updated
- [ N/A ] README and other documentation has been updated / added (if needed)
- [ X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
