### PR TITLE
FS-3577 Fixed last edited time displaying noon as midnight

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -13,8 +13,8 @@ def datetime_format_short_month(value: datetime) -> str:
     if value:
         formatted_date = format_datetime(value, format="dd MMM yyyy ")
         formatted_date += gettext("at")
-        formatted_date += format_datetime(value, format=" HH:mm", rebase=False)
-        formatted_date += format_datetime(value, "a").lower()
+        formatted_date += format_datetime(value, format=" h:mm", rebase=False)
+        formatted_date += format_datetime(value, "a", rebase=False).lower()
         return formatted_date
     else:
         return ""


### PR DESCRIPTION
### Change description
Fixed the time displayed on the applications page to fit the govuk guidelines by making it use a 12 hour time format. Also fixing the am/pm being incorrect when showing noon or midnight

- [ N/A ] Unit tests and other appropriate tests added or updated
- [ N/A ] README and other documentation has been updated / added (if needed)
- [ X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
When opening the last edited page the following should be true
- Last edited value should in the 12 hour clock format
- If an application was last edited at 12 last edited should display the correct suffix


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-frontend/assets/37579353/b5edc720-2243-4209-9432-2588fbc7018c)

