### PR TITLE
BAU Fixing dependabot errors for copilot deploys

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -79,6 +79,7 @@ jobs:
           fi
 
   copilot_env_deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     concurrency:
       group: '${{ github.workflow }} @ ${{ github.ref }}'
       cancel-in-progress: false


### PR DESCRIPTION
### Change description

* dependabot does not have access to github secrets
* We don't want to run builds without access to secrets
* Add in a rule to ignore dependabot deploys

+ref: BAU
+semver: minor

- [N/A] Unit tests and other appropriate tests added or updated
- [N/A] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")