### PR TITLE
BAU Remove continue-on-error

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -91,7 +91,6 @@ jobs:
       contents: read  # This is required for actions/checkout
     needs: [ tag_version, pre_deploy_tests, paketo_build, copilot_environments_workflow_setup ]
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       max-parallel: 1
       matrix:


### PR DESCRIPTION
# Description

We don't want to continue the workflow beyond any deploy that fails.

