### PR TITLE
Fs 3964 fix fund title

### DIFF
--- a/app/default/account_routes.py
+++ b/app/default/account_routes.py
@@ -29,7 +29,6 @@ def get_visible_funds(visible_fund_short_name):
     :param visible_fund_short_name: short name to look for
     """
     all_funds = get_all_funds(get_lang(), get_ttl_hash(Config.LRU_CACHE_TIME))
-    
 
     if visible_fund_short_name:
         funds_to_show = [
@@ -86,6 +85,7 @@ def build_application_data_for_display(
         fund_id = fund["id"]
         all_rounds_in_fund = get_all_rounds_for_fund(
             fund_id,
+            language=get_lang(),
             as_dict=False,
             ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
         )

--- a/app/default/account_routes.py
+++ b/app/default/account_routes.py
@@ -28,7 +28,8 @@ def get_visible_funds(visible_fund_short_name):
 
     :param visible_fund_short_name: short name to look for
     """
-    all_funds = get_all_funds(ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME))
+    all_funds = get_all_funds(get_lang(), get_ttl_hash(Config.LRU_CACHE_TIME))
+    
 
     if visible_fund_short_name:
         funds_to_show = [

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -187,7 +187,9 @@ def get_fund_data(fund_id, language=None, as_dict=False, ttl_hash=None):
 
 
 @lru_cache(maxsize=5)
-def get_fund_data_by_short_name(fund_short_name, as_dict=False, ttl_hash=None):
+def get_fund_data_by_short_name(
+    fund_short_name, language=None, as_dict=False, ttl_hash=None
+):
     del ttl_hash  # Only needed for lru_cache
     all_funds = {fund["short_name"].lower() for fund in get_all_funds()}
     if fund_short_name.lower() not in all_funds:
@@ -196,7 +198,7 @@ def get_fund_data_by_short_name(fund_short_name, as_dict=False, ttl_hash=None):
     fund_request_url = Config.GET_FUND_DATA_BY_SHORT_NAME_ENDPOINT.format(
         fund_short_name=fund_short_name.lower()
     )
-    params = {"language": get_lang(), "use_short_name": True}
+    params = {"language": language or get_lang(), "use_short_name": True}
     fund_response = get_data_or_fail_gracefully(fund_request_url, params)
     if as_dict:
         return fund_response
@@ -242,6 +244,7 @@ def get_application_display_config(fund_id, round_id, language):
 def get_round_data_by_short_names(
     fund_short_name,
     round_short_name,
+    language=None,
     as_dict=False,
     ttl_hash=None,
 ) -> Round | dict:
@@ -249,7 +252,7 @@ def get_round_data_by_short_names(
     all_rounds = [
         rnd.short_name.lower()
         for rnd in get_all_rounds_for_fund(
-            fund_short_name, use_short_name=True
+            fund_short_name, use_short_name=True, language=get_lang()
         )
     ]
     if round_short_name.lower() not in all_rounds:
@@ -257,7 +260,7 @@ def get_round_data_by_short_names(
             f"Invalid round {round_short_name.lower()}!"
         )
         return None
-    params = {"language": get_lang(), "use_short_name": "true"}
+    params = {"language": language or get_lang(), "use_short_name": "true"}
 
     request_url = Config.GET_ROUND_DATA_BY_SHORT_NAME_ENDPOINT.format(
         fund_short_name=fund_short_name.lower(),
@@ -277,6 +280,7 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
                 round_response = get_round_data_by_short_names(
                     fund_id,
                     round_id,
+                    get_lang(),
                     ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
                     as_dict=True,
                 )
@@ -284,6 +288,7 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
                 round_response = get_round_data(
                     fund_id,
                     round_id,
+                    get_lang(),
                     get_ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
                     as_dict=True,
                 )
@@ -348,17 +353,17 @@ def get_account(email: str = None, account_id: str = None) -> Account | None:
 @lru_cache(maxsize=1)
 def get_all_funds(language=None, ttl_hash=None):
     del ttl_hash  # Only needed for lru_cache
-    language = {"language": language if language else get_lang()}
+    language = {"language": language or get_lang()}
     fund_response = get_data(Config.GET_ALL_FUNDS_ENDPOINT, language)
     return fund_response
 
 
 @lru_cache(maxsize=5)
 def get_all_rounds_for_fund(
-    fund_id, as_dict=False, use_short_name=False, ttl_hash=None
+    fund_id, language, as_dict=False, use_short_name=False, ttl_hash=None
 ):
     del ttl_hash  # Only needed for lru_cache
-    params = {"language": get_lang()}
+    params = {"language": language or get_lang()}
     if use_short_name:
         params["use_short_name"] = "true"
     rounds_response = get_data_or_fail_gracefully(
@@ -408,6 +413,7 @@ def get_default_round_for_fund(fund_short_name: str) -> Round:
     try:
         rounds = get_all_rounds_for_fund(
             fund_short_name,
+            get_lang(),
             as_dict=False,
             use_short_name=True,
             ttl_hash=get_ttl_hash(),

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -350,7 +350,7 @@ def get_account(email: str = None, account_id: str = None) -> Account | None:
         return Account.from_json(response)
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=2)
 def get_all_funds(language=None, ttl_hash=None):
     del ttl_hash  # Only needed for lru_cache
     language = {"language": language or get_lang()}

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -346,9 +346,9 @@ def get_account(email: str = None, account_id: str = None) -> Account | None:
 
 
 @lru_cache(maxsize=1)
-def get_all_funds(ttl_hash=None):
+def get_all_funds(language=None, ttl_hash=None):
     del ttl_hash  # Only needed for lru_cache
-    language = {"language": get_lang()}
+    language = {"language": language if language else get_lang()}
     fund_response = get_data(Config.GET_ALL_FUNDS_ENDPOINT, language)
     return fund_response
 

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -18,6 +18,7 @@ from app.models.round import Round
 from config import Config
 from flask import current_app
 from flask import request
+from fsd_utils.locale_selector.get_lang import get_lang
 
 
 @lru_cache(maxsize=1)
@@ -232,6 +233,7 @@ def get_fund(
         else (
             get_fund_data_by_short_name(
                 fund_short_name,
+                get_lang(),
                 as_dict=False,
                 ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
             )
@@ -251,7 +253,9 @@ def get_round(
 ) -> Round:
     if fund_short_name:
         fund = get_fund_data_by_short_name(
-            fund_short_name, ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME)
+            fund_short_name,
+            get_lang(),
+            ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
         )
     elif fund_id:
         fund = get_fund_data(
@@ -273,6 +277,7 @@ def get_round(
             get_round_data_by_short_names(
                 fund.short_name,
                 round_short_name,
+                get_lang(),
                 as_dict=False,
                 ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,3 +155,4 @@ def mock_get_fund_round(mocker):
         "app.default.data.get_round_data_fail_gracefully",
         return_value=TEST_ROUNDS_DATA[0],
     )
+    mocker.patch("app.default.account_routes.get_lang", return_value="en")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -306,7 +306,7 @@ def test_build_application_data_for_display(
     )
     mocker.patch(
         "app.default.account_routes.get_all_rounds_for_fund",
-        new=lambda fund_id, as_dict, ttl_hash: [
+        new=lambda fund_id, language, as_dict, ttl_hash: [
             round for round in rounds if round.fund_id == fund_id
         ],
     )

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,5 +1,6 @@
 import time
 
+from app.default.data import get_all_funds
 from app.default.data import get_fund_data
 from app.default.data import get_ttl_hash
 
@@ -43,3 +44,38 @@ def test_get_fund_data_lru_cache(mocker):
         fund_id="222", language="en", ttl_hash=get_ttl_hash(seconds=2)
     )
     assert fund.name == "Testing Fund 2"
+
+
+def test_get_all_funds_cache_with_language(mocker):
+    mocker.patch(
+        "app.default.data.get_data",
+        return_value=[
+            {
+                "name": "Testing Fund",
+                "id": "222",
+            }
+        ],
+    )
+    en = "en"
+    # `get_all_funds`'s output is cached for 5 secs
+    funds = get_all_funds(language=en, ttl_hash=get_ttl_hash(seconds=300))
+    assert funds[0]["name"] == "Testing Fund"
+
+    # Now let's make another call to `get_all_funds` with modified fund data(in db) in less than 5 sec
+    mocker.patch(
+        "app.default.data.get_data",
+        return_value=[
+            {
+                "name": "Testing Fund 2",
+                "id": "222",
+            }
+        ],
+    )
+    funds = get_all_funds(language=en, ttl_hash=get_ttl_hash(seconds=300))
+    assert funds[0]["name"] == "Testing Fund"
+    # observe that fund name is still equal to cached title
+
+    # Now make another call but with a different language
+    funds = get_all_funds(language="cy", ttl_hash=get_ttl_hash(seconds=300))
+    assert funds[0]["name"] == "Testing Fund 2"
+    # observe that we now get back the new value as changing the langauge has invalidated the cache

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -150,6 +150,7 @@ def test_start_page_closed(client, mocker, templates_rendered):
     ],
 )
 def test_get_default_round_for_fund(rounds, expected_default_id, mocker):
+    mocker.patch("app.default.data.get_lang", return_value="en")
     mocker.patch(
         "app.default.data.get_all_rounds_for_fund", return_value=rounds
     )
@@ -158,6 +159,7 @@ def test_get_default_round_for_fund(rounds, expected_default_id, mocker):
 
 
 def test_get_default_round_for_fund_no_rounds(mocker):
+    mocker.patch("app.default.data.get_lang", return_value="en")
     mocker.patch("app.default.data.get_all_rounds_for_fund", return_value=[])
     result = get_default_round_for_fund("fund")
     assert result is None


### PR DESCRIPTION
### Change description
When switching between welsh and english on the dashboard, the fund title was not always translating correctly. This was due to the caching on retrieval of fund data - the cache wasn't invalidated by the change of language.

Updated the fund retrieval method to take in the language and increased the cache size to 2, meaning that when changing languages we always get the right value. Also checked other fund retrieval methods to make them respect language choice with the caching, and updated unit tests to mock the `get_lang()` function as needed.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Navigate to the dashboard
Switch between welsh and english - observe the fund title being correctly translated


### Screenshots of UI changes (if applicable)
![Screenshot 2024-01-10 at 07 56 40](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/59a39fe9-a19e-4e3a-a36b-ff85097bc3dc)
![Screenshot 2024-01-10 at 07 56 56](https://github.com/communitiesuk/funding-service-design-frontend/assets/1729216/850a4883-9851-4396-a93f-d36c6c3b5955)
