### PR TITLE
fs-2942 dashboard forces language if welsh not avaialble, added tests

### DIFF
--- a/app/templates/dashboard_all.html
+++ b/app/templates/dashboard_all.html
@@ -24,7 +24,6 @@
         {% set application_count=display_data["total_applications_to_display"]%}
         {% trans %}You have started{% endtrans %}&nbsp;{% trans count=application_count%} {{application_count}} application{% pluralize %}{{application_count}} applications{% endtrans %}&nbsp;{% trans %}using this email address{% endtrans %}.
     </p>
-{{available_in_language(inset=False, warn=True, welsh_available=welsh_available)}}
 
 <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     {% for fund in display_data["funds"] %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,13 +67,13 @@ def app():
 
 
 @pytest.fixture()
-def flask_test_client():
+def flask_test_client(app):
     """
     Creates the test client we will be using to test the responses
     from our app, this is a test fixture.
     :return: A flask test client.
     """
-    with create_app().test_client() as test_client:
+    with app.test_client() as test_client:
         yield test_client
 
 

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -10,6 +10,7 @@ from tests.api_data.test_data import TEST_APPLICATION_SUMMARIES
 from tests.api_data.test_data import TEST_APPLICATIONS
 from tests.api_data.test_data import TEST_DISPLAY_DATA
 from tests.api_data.test_data import TEST_FUNDS_DATA
+from tests.utils import get_language_cookie_value
 
 file = open("tests/api_data/endpoint_data.json")
 data = json.loads(file.read())
@@ -104,16 +105,6 @@ def test_tasklist_for_submit_application_route(
         },
         as_dict=False,
     )
-
-
-def get_language_cookie_value(response):
-    cookie_header = response.headers["Set-Cookie"]
-    lang_index = response.headers["Set-Cookie"].find("language=")
-    lang_index = lang_index + len("language=")
-    current_set_language = str(cookie_header)[
-        lang_index : lang_index + 2  # noqa: E203
-    ]
-    return current_set_language
 
 
 def test_language_cookie_update_welsh_to_english(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,16 @@ from config import Config
 from flask import url_for
 
 
+def get_language_cookie_value(response):
+    cookie_header = response.headers["Set-Cookie"]
+    lang_index = response.headers["Set-Cookie"].find("language=")
+    lang_index = lang_index + len("language=")
+    current_set_language = str(cookie_header)[
+        lang_index : lang_index + 2  # noqa: E203
+    ]
+    return current_set_language
+
+
 def get_service_html_filepath(
     root_dir: str, service_dict: dict, route_rel: str
 ):


### PR DESCRIPTION
### Change description
If you are in welsh, and move from the all applications view to a specific fund dashboard, and that fund does not support welsh, forces the language cookie to welsh.

Also added some missing unit tests for existing functionality, as well as testing this fix.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Navigate to a fund that supports welsh
- Change to welsh
- Navigate to 'view all my applications'
- Navigate to a fund that does not support welsh
- The dashboard for that fund should force you into english - all text should display in english and the cookie should change to `en`
