### PR TITLE
fs-4144 updating rules on which applications to display

### DIFF
--- a/app/default/account_routes.py
+++ b/app/default/account_routes.py
@@ -72,7 +72,9 @@ def update_applications_statuses_for_display(
     return applications
 
 
-def build_application_data_for_display(applications: list[ApplicationSummary], visible_fund_short_name):
+def build_application_data_for_display(
+    applications: list[ApplicationSummary], visible_fund_short_name, visible_round_short_name
+):
     application_data_for_display = {
         "funds": [],
         "total_applications_to_display": 0,
@@ -93,6 +95,9 @@ def build_application_data_for_display(applications: list[ApplicationSummary], v
             "rounds": [],
         }
         for round in all_rounds_in_fund:
+            if visible_round_short_name:
+                if round.short_name.casefold() != visible_round_short_name.casefold():
+                    continue
             round_status = determine_round_status(round)
             apps_in_this_round = [app for app in applications if app.round_id == round.id]
             if round_status.not_yet_open or (round_status.past_submission_deadline and len(apps_in_this_round) == 0):
@@ -134,8 +139,8 @@ def determine_show_language_column(applications: ApplicationSummary):
 def dashboard():
     account_id = g.account_id
 
-    fund_short_name = request.args.get("fund")
-    round_short_name = request.args.get("round")
+    fund_short_name = request.args.get("fund", None)
+    round_short_name = request.args.get("round", None)
     render_lang = get_lang()
 
     if fund_short_name and round_short_name:
@@ -174,7 +179,7 @@ def dashboard():
 
     show_language_column = determine_show_language_column(applications)
 
-    display_data = build_application_data_for_display(applications, fund_short_name)
+    display_data = build_application_data_for_display(applications, fund_short_name, round_short_name)
     current_app.logger.info(f"Setting up applicant dashboard for :'{account_id}'")
     if not welsh_available and template_name == TEMPLATE_SINGLE_FUND:
         render_lang = "en"

--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -15,9 +15,6 @@ default_bp = Blueprint("routes", __name__, template_folder="templates")
 
 @default_bp.route("/")
 def index():
-    """
-    Redirects from the old landing page to the new one at /cof/r2w3
-    """
     return abort(404)
 
 
@@ -25,10 +22,6 @@ def index():
 def index_fund_round(fund_short_name, round_short_name):
     current_app.logger.info(f"In fund-round start page {fund_short_name} {round_short_name}")
 
-    # fund_data = get_fund_data_by_short_name(fund_short_name, as_dict=False)
-    # round_data = get_round_data_by_short_names(
-    #     fund_short_name, round_short_name
-    # )
     fund_data, round_data = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_short_name)
     if not fund_data or not round_data:
         abort(404)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -247,7 +247,8 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
 
 
 @pytest.mark.parametrize(
-    "funds,rounds,applications,expected_fund_count,expected_round_count,expected_app_count, fund_short_name",
+    "funds,rounds,applications,expected_fund_count,expected_round_count,expected_app_count,"
+    " fund_short_name,round_short_name",
     [
         # No filters, 2 funds with 2 rounds each
         (
@@ -257,6 +258,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             2,
             4,
             4,
+            None,
             None,
         ),
         # No fund filter, one fund with no rounds one fund with 2 rounds
@@ -268,6 +270,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             2,
             2,
             None,
+            None,
         ),
         # Filter to fund with open rounds
         (
@@ -278,6 +281,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             2,
             2,
             "FSD",
+            None,
         ),
         # Filter to fund with no rounds
         (
@@ -288,6 +292,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             0,
             0,
             "FSD2",
+            None,
         ),
         # 1 app in closed round, 0 in open round
         (
@@ -298,6 +303,29 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             2,
             1,
             "FSD",
+            None,
+        ),
+        # 1 app in closed round, 0 in open round - filter to closed round
+        (
+            TEST_FUNDS_DATA,
+            TEST_ROUNDS_DATA,
+            TEST_APPLICATION_SUMMARIES[0:1],
+            1,
+            1,
+            1,
+            "FSD",
+            "r2w2",
+        ),
+        # 1 app in closed round, 0 in open round - filter to open round
+        (
+            TEST_FUNDS_DATA,
+            TEST_ROUNDS_DATA,
+            TEST_APPLICATION_SUMMARIES[0:1],
+            1,
+            1,
+            0,
+            "FSD",
+            "r2w3",
         ),
         # 1 app in open round, 0 in closed round
         (
@@ -308,6 +336,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             1,
             1,
             "FSD",
+            None,
         ),
         # 1 fund with 2 rounds and 2 apps, 1 fund with 1 closed round and no
         # apps
@@ -319,6 +348,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             2,
             2,
             None,
+            None,
         ),
         # 1 open round, 0 applications
         (
@@ -328,6 +358,7 @@ def test_dashboard_route_no_applications(flask_test_client, mocker, mock_login):
             1,
             1,
             0,
+            None,
             None,
         ),
     ],
@@ -340,6 +371,7 @@ def test_build_application_data_for_display(
     expected_round_count,
     expected_app_count,
     fund_short_name,
+    round_short_name,
     mocker,
 ):
     mocker.patch(
@@ -351,7 +383,7 @@ def test_build_application_data_for_display(
         new=lambda fund_id, language, as_dict, ttl_hash: [round for round in rounds if round.fund_id == fund_id],
     )
 
-    result = build_application_data_for_display(applications, fund_short_name)
+    result = build_application_data_for_display(applications, fund_short_name, round_short_name)
 
     assert result["total_applications_to_display"] == expected_app_count
     assert len(result["funds"]) == expected_fund_count

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -75,7 +75,7 @@ def test_dashboard_route_search_call(
 ):
     request_mock = mocker.patch("app.default.account_routes.request")
     request_mock.args.get = (
-        lambda key: fund_short_name if key == "fund" else (round_short_name if key == "round" else None)
+        lambda key, default: fund_short_name if key == "fund" else (round_short_name if key == "round" else default)
     )
     get_apps_mock = mocker.patch(
         "app.default.account_routes.search_applications",


### PR DESCRIPTION
### Change description
Updated `build_application_Data_for_display` to filter applications to only the visible round if `round_short_name` is displayed. eg:
- `frontend/account?fund=COF&round=R3W3` will only display applications from R3W3
- `frontend/account?fund=COF` will still display any applications from all rounds in that fund

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
