### PR TITLE
FS-4322-fix-workflow-file-package.yml-direct-to-main

### DIFF
--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -23,6 +23,6 @@ jobs:
     needs: tag-to-release
     permissions:
       packages: write
-    uses: ./.github/workflows/package.yml
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
     with:
       version_to_build: ${{ needs.tag-to-release.outputs.new_tag }}


### PR DESCRIPTION
Some of the workflow files that was commonly used across services, those were moved to the main to avoid repetition. It seems that one of the file on Frontend wasn't  directed to main. 

https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4322