### PR TITLE
FS-4055: Crown logo update frontend

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,8 +2,6 @@
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
-
-
 {% block pageTitle %}{{[pageHeading, service_title]|join(' - ') if pageHeading else service_title}}{% endblock %}
 
 {% block head %}
@@ -20,8 +18,11 @@
 
 {% block bodyEnd %}
   <!--[if gt IE 8]><!-->
-  <script src="{{ url_for('static', filename='govuk-frontend-4.0.0.min.js') }}"> </script>
-  <script>window.GOVUKFrontend.initAll()</script>
+    <script nonce="{{ csp_nonce() }}" type="module" src="{{ url_for('static', filename='govuk-frontend-5.3.0.min.js') }}"></script>
+    <script type="module">
+      import { initAll } from "{{ url_for('static', filename='govuk-frontend-5.3.0.min.js') }}"
+      window.GOVUKFrontend.initAll();
+    </script>
   <!--<![endif]-->
     <!-- Google Tag Manager (noscript) -->
     <noscript>

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -3,7 +3,7 @@
 <meta name="author" content="{{ service_meta_author }}">
 
 <!--[if gt IE 8]><!-->
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-4.0.0.min.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-5.3.0.min.css') }}" />
 <!--<![endif]-->
 <!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-ie8-4.0.0.min.css') }}" /><![endif]-->
 <link rel="stylesheet" type="text/css" href="{{ url_for('static',filename='styles/tasklist.css') }}">

--- a/build.py
+++ b/build.py
@@ -15,7 +15,7 @@ def build_assets():
     # Download zips using "url"
     print("Downloading static file zip.")
 
-    url = "https://github.com/alphagov/govuk-frontend/releases/download/v4.0.0/release-v4.0.0.zip"
+    url = "https://github.com/alphagov/govuk-frontend/releases/download/v5.3.0/release-v5.3.0.zip"
 
     # There is a known problem on Mac where one must manually
     # run the script "Install Certificates.command" found

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -93,6 +93,7 @@ class DefaultConfig:
             "'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='",
             "'sha256-z+p4q2n8BOpGMK2/OMOXrTYmjbeEhWQQHC3SF/uMOyg='",
             "'sha256-RgdCrr7A9yqYVstE6QiM/9RNRj4bYipcUa2C2ywQT1A='",
+            "'sha256-mHFps5pHezl0ZUJ5S0eWPPUEo9rdX5vu8+fnsqPZfrs='",
             "https://tagmanager.google.com",
             "https://www.googletagmanager.com",
             "https://*.google-analytics.com",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -144,7 +144,7 @@ flipper-client==1.3.2
     #   funding-service-design-utils
 funding-service-design-utils==2.0.40
     # via -r requirements.txt
-govuk-frontend-jinja==2.7.0
+govuk-frontend-jinja==2.8.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via


### PR DESCRIPTION
### Change description

- govuk-fronend version updated to 5.3.0 from 4.0.0 which includes updated crown assets
- govuk-frontend-jinja updated to 2.8.0 from 2.3.0 which includes the latest crown logo svg
- updated the assetPath variable to the correct location for assets

### Ticket
https://dluhcdigital.atlassian.net/browse/FS-4055

### How to test
- By going to the frontend endpoint


### Screenshots of UI changes (if applicable)
<img width="813" alt="Screenshot 2024-04-17 at 15 38 46" src="https://github.com/communitiesuk/funding-service-design-frontend/assets/66220499/183967e3-42ce-4327-8929-3e108318922d">