### PR TITLE
Fs 4430 remove email msg

### DIFF
--- a/app/templates/partials/round_closed_warning.html
+++ b/app/templates/partials/round_closed_warning.html
@@ -7,15 +7,19 @@
         </h2>
     </div>
     <div class="govuk-notification-banner__content">
+        {% if round_title in ["Expression of interest","Mynegi diddordeb"] %}
         <h2 class="govuk-notification-banner__heading">
-            Window closed - {{ fund_name }} {{ round_title }}
+            Window closed - {{ fund_name }}
         </h2>
         <p class="govuk-body">(Closed: {{ submission_deadline|datetime_format }})</p>
-        {% if round_title in ["Expression of interest","Mynegi diddordeb"] %}
         <p class="govuk-body">We have now entered a pre-election period. There will be no further Community Ownership
             Fund announcements at this time.</p>
             <p class="govuk-body">You can no longer submit applications in this window.</p>
         {% else %}
+        <h2 class="govuk-notification-banner__heading">
+            Window closed - {{ fund_name }} {{ round_title }}
+        </h2>
+        <p class="govuk-body">(Closed: {{ submission_deadline|datetime_format }})</p>
         <p class="govuk-body">You can no longer submit applications in this window. Any you had in progress will be
             emailed to you.</p>
         {% endif %}

--- a/app/templates/partials/round_closed_warning.html
+++ b/app/templates/partials/round_closed_warning.html
@@ -14,9 +14,11 @@
         {% if round_title in ["Expression of interest","Mynegi diddordeb"] %}
         <p class="govuk-body">We have now entered a pre-election period. There will be no further Community Ownership
             Fund announcements at this time.</p>
-        {% endif %}
+            <p class="govuk-body">You can no longer submit applications in this window.</p>
+        {% else %}
         <p class="govuk-body">You can no longer submit applications in this window. Any you had in progress will be
             emailed to you.</p>
+        {% endif %}
     </div>
 </div>
 {% endmacro %}


### PR DESCRIPTION
COF have confirmed they do not want us to email any incomplete EOI applications when the round closes tonight. We need to amend the 'window closed' banner text as at the moment it says we will email these.

