### PR TITLE
FS-4411:Over-provision instance and change to Fargate-spot

### DIFF
--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -64,9 +64,14 @@ secrets:
 
 # You can override any of the values defined above by environment.
 environments:
+  dev:
+    count:
+      spot: 1
   test:
     deployment:
       rolling: 'recreate'
+    count:
+      spot: 2
   uat:
     http:
       alias: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"


### PR DESCRIPTION
FS-4411: Overprovision instance

##Change description
Reduce the number of instance to 1 in Dev and change the ECS launch_type to Fargate-spot.

Unit tests and other appropriate tests added or updated
README and other documentation has been updated / added (if needed)
Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
How to test
_Will check after deployment by logging into the ECS console and view the service and instance configuration

Screenshots of UI changes (if applicable)

