### PR TITLE
FS-3888:add-id-to-start-new-application-v1

### DIFF
--- a/app/templates/dashboard_single_fund.html
+++ b/app/templates/dashboard_single_fund.html
@@ -49,7 +49,7 @@ Your applications
                     {% if round["round_details"]["has_eligibility"] %}
                         {{ eligibilityCheckButton(form, url_for('eligibility_routes.launch_eligibility', fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"])) }}
                     {% else %}
-                        {{ startApplicationButton(form, url_for('account_routes.new'), fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"], eligibility_confirm=False, existing_applications_count=round["applications"]|count) }}
+                        {{ startApplicationButton(form, url_for('account_routes.new'), fund_id=fund["fund_data"]["id"], round_id=round["round_details"]["id"], eligibility_confirm=False, existing_applications_count=round["applications"]|count,fund_info='start_application_'+ fund["fund_data"]["short_name"] + '_' +round["round_details"]["short_name"]) }}
                     {% endif %}
                 {% endif %}
             {% endif %}

--- a/app/templates/partials/start-application-button.html
+++ b/app/templates/partials/start-application-button.html
@@ -1,13 +1,13 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
-{% macro startApplicationButton(form, url, fund_id, round_id, eligibility_confirm, existing_applications_count) %}
+{% macro startApplicationButton(form, url, fund_id, round_id, eligibility_confirm, existing_applications_count, fund_info=None) %}
     <form method="post" action={{ url }} >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <input type="hidden" name="account_id" value="{{ account_id }}">
         <input type="hidden" name="fund_id" value="{{ fund_id }}">
         <input type="hidden" name="round_id" value="{{ round_id }}">
 
-        {{ govukButton({
+        {{ govukButton({ 'id': fund_info if fund_info,
             'text': gettext('Continue application') if eligibility_confirm else gettext('Start new application'),
             'classes': 'govuk-button--secondary' if existing_applications_count>0
         }) }}


### PR DESCRIPTION
When there are 2 rounds open in the same fund, the automated tests just use the first ‘start a new application’ button they find. If we add an id to the button that includes the fund/round short names we can select based on which round we are targeting.

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### How to test
Manually Tested

### Screenshots of UI changes (if applicable)
<img width="1191" alt="image" src="https://github.com/communitiesuk/funding-service-design-frontend/assets/168304739/eb4b31a3-73a3-4309-a2ff-8eaf423a38dc">
