### PR TITLE
Courtesy PR bumping utils to pull in `toggles` extra

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ babel==2.14.0
     # via
     #   -r requirements.txt
     #   flask-babel
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -r requirements-dev.in
     #   -r requirements.txt
@@ -92,7 +92,7 @@ dparse==0.6.3
     # via -r requirements-dev.in
 email-validator==2.1.1
     # via -r requirements.txt
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via pytest
 filelock==3.13.1
     # via virtualenv
@@ -121,7 +121,7 @@ flask-babel==2.0.0
     #   funding-service-design-utils
 flask-compress==1.14
     # via -r requirements.txt
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
@@ -142,7 +142,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.52
+funding-service-design-utils[toggles]==5.0.1
     # via -r requirements.txt
 govuk-frontend-jinja==2.7.0
     # via -r requirements.txt
@@ -237,7 +237,6 @@ pyjwt[crypto]==2.8.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-    #   pyjwt
 pyproject-hooks==1.0.0
     # via build
 pyscss==1.4.0
@@ -262,7 +261,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements.txt
     #   botocore
-python-dotenv==0.20.0
+python-dotenv==1.0.1
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
@@ -287,7 +286,7 @@ redis==4.6.0
     #   -r requirements.txt
     #   flask-redis
     #   flipper-client
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
@@ -303,11 +302,10 @@ s3transfer==0.10.0
     # via
     #   -r requirements.txt
     #   boto3
-sentry-sdk[flask]==1.39.1
+sentry-sdk[flask]==2.11.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-    #   sentry-sdk
 six==1.16.0
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #-----------------------------------
 #   FSD Utils
 #-----------------------------------
-funding-service-design-utils>=2.0.48,<2.1.0
+funding-service-design-utils[toggles]
 requests
 
 #-----------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ async-timeout==4.0.3
     # via redis
 babel==2.14.0
     # via flask-babel
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via funding-service-design-utils
 blinker==1.7.0
     # via
@@ -66,7 +66,7 @@ flask-babel==2.0.0
     #   funding-service-design-utils
 flask-compress==1.14
     # via -r requirements.in
-flask-migrate==4.0.5
+flask-migrate==4.0.7
     # via funding-service-design-utils
 flask-redis==0.4.0
     # via funding-service-design-utils
@@ -80,7 +80,7 @@ flask-wtf==1.2.1
     # via -r requirements.in
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.52
+funding-service-design-utils[toggles]==5.0.1
     # via -r requirements.in
 govuk-frontend-jinja==2.7.0
     # via -r requirements.in
@@ -121,16 +121,14 @@ pyee==6.0.0
 pygments==2.17.2
     # via rich
 pyjwt[crypto]==2.8.0
-    # via
-    #   funding-service-design-utils
-    #   pyjwt
+    # via funding-service-design-utils
 pyscss==1.4.0
     # via -r requirements.in
 python-consul==1.1.0
     # via flipper-client
 python-dateutil==2.8.2
     # via botocore
-python-dotenv==0.20.0
+python-dotenv==1.0.1
     # via funding-service-design-utils
 python-json-logger==2.0.7
     # via funding-service-design-utils
@@ -146,7 +144,7 @@ redis==4.6.0
     # via
     #   flask-redis
     #   flipper-client
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   funding-service-design-utils
@@ -155,10 +153,8 @@ rich==12.6.0
     # via funding-service-design-utils
 s3transfer==0.10.0
     # via boto3
-sentry-sdk[flask]==1.39.1
-    # via
-    #   funding-service-design-utils
-    #   sentry-sdk
+sentry-sdk[flask]==2.11.0
+    # via funding-service-design-utils
 six==1.16.0
     # via
     #   pyscss


### PR DESCRIPTION
### Change description
[FSD-utils made the `toggles` module an optional extra](https://github.com/communitiesuk/funding-service-design-utils/pull/153), so it now needs to be pulled in explicitly. This patch does that.

---

utils v3 breaking change: upgrade sentry to v2
(https://github.com/communitiesuk/funding-service-design-utils/pull/146)

utils v4 breaking change: dependency updates and urlencode the redirect
(https://github.com/communitiesuk/funding-service-design-utils/commit/2c68a71654699eccebe27b896778ae1f1c29520b)

utils v5 breaking change: make `toggles` an optional extra
(https://github.com/communitiesuk/funding-service-design-utils/pull/153)