### PR TITLE
FS-3664 View submitted applications and applications for previous rounds

### DIFF
--- a/app/create_app.py
+++ b/app/create_app.py
@@ -9,6 +9,7 @@ from app.filters import kebab_case_to_human
 from app.filters import snake_case_to_human
 from app.filters import status_translation
 from app.filters import string_to_datetime
+from app.filters import string_to_datetime_ms
 from app.helpers import find_fund_and_round_in_request
 from app.helpers import find_fund_in_request
 from config import Config
@@ -96,6 +97,7 @@ def create_app() -> Flask:
     flask_app.jinja_env.filters["datetime_format_short_month"] = datetime_format_short_month
     flask_app.jinja_env.filters["datetime_format_full_month"] = datetime_format_full_month
     flask_app.jinja_env.filters["string_to_datetime"] = string_to_datetime
+    flask_app.jinja_env.filters["string_to_datetime_ms"] = string_to_datetime_ms
     flask_app.jinja_env.filters["custom_format_datetime"] = custom_format_datetime
     flask_app.jinja_env.filters["date_format_short_month"] = date_format_short_month
     flask_app.jinja_env.filters["datetime_format"] = datetime_format

--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from functools import wraps
 from http.client import METHOD_NOT_ALLOWED
 
@@ -49,8 +48,6 @@ from fsd_utils.locale_selector.set_lang import LanguageSelector
 from fsd_utils.simple_utils.date_utils import (
     current_datetime_after_given_iso_string,
 )
-from pytz import timezone
-
 
 application_bp = Blueprint("application_routes", __name__, template_folder="templates")
 
@@ -140,7 +137,6 @@ def verify_round_open(f):
 @application_bp.route("/tasklist/<application_id>", methods=["GET"])
 @login_required
 @verify_application_owner_local
-# @verify_round_open
 def tasklist(application_id):
     """
     Returns a Flask function which constructs a tasklist for an application id.
@@ -278,12 +274,6 @@ def tasklist(application_id):
             submission_deadline=round_data.deadline,
             is_expression_of_interest=round_data.is_expression_of_interest,
             is_past_submission_deadline=current_datetime_after_given_iso_string(round_data.deadline),  # noqa:E501
-            # note I suspect this is what some of the utils are here do -- could avoid doing it myself
-            application_submitted_at=datetime.fromisoformat(application.date_submitted).astimezone(
-                timezone("Europe/London")
-            )
-            if (application.date_submitted and application.date_submitted != "null")
-            else None,
             dashboard_url=url_for(
                 "account_routes.dashboard",
                 fund=fund_data.short_name,

--- a/app/filters.py
+++ b/app/filters.py
@@ -85,6 +85,10 @@ def string_to_datetime(value: str) -> datetime:
     return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
 
+def string_to_datetime_ms(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+
+
 def datetime_format_full_month(value: datetime) -> str:
     if not value:
         return ""

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -75,6 +75,7 @@ def format_rehydrate_payload(
     fund_name=None,
     round_name=None,
     has_eligibility=False,
+    is_read_only_summary=False,
 ):
     """
     Returns information in a JSON format that provides the
@@ -133,6 +134,10 @@ def format_rehydrate_payload(
     formatted_data["metadata"]["fund_name"] = fund_name
     formatted_data["metadata"]["round_name"] = round_name
     formatted_data["metadata"]["has_eligibility"] = has_eligibility
+
+    if is_read_only_summary:
+        formatted_data["options"]["redirectPath"] = "/summary"
+        formatted_data["metadata"]["is_read_only_summary"] = True
 
     return formatted_data
 

--- a/app/templates/partials/applications_table.html
+++ b/app/templates/partials/applications_table.html
@@ -26,13 +26,10 @@
 		{% endif %}
 		{% endset %}
 
-
-        {% if application.status == 'SUBMITTED' %}
-
-		{% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id), "View application") %}
-
-        {% elif not application.status == 'SUBMITTED' and not is_past_submission_deadline %}
+        {% if not application.status == 'SUBMITTED' and not is_past_submission_deadline %}
 			{% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id), gettext('Continue application')) %}
+        {% else %}
+		    {% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id), "View application") %}
 		{% endif %}
 
 		{% set row = [

--- a/app/templates/partials/applications_table.html
+++ b/app/templates/partials/applications_table.html
@@ -26,7 +26,12 @@
 		{% endif %}
 		{% endset %}
 
-		{% if not application.status == 'SUBMITTED' and not is_past_submission_deadline %}
+
+        {% if application.status == 'SUBMITTED' %}
+
+		{% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id), "View application") %}
+
+        {% elif not application.status == 'SUBMITTED' and not is_past_submission_deadline %}
 			{% set application_link = '<a class="govuk-link" href="{}">{}</a>'.format(url_for('application_routes.tasklist', application_id=application.id), gettext('Continue application')) %}
 		{% endif %}
 
@@ -55,13 +60,11 @@
         %}
 		{% endif %}
 
-        {% if not is_past_submission_deadline %}
-            {% set action = row.append(
-                {
-                    'html': application_link
-                })
+        {% set action = row.append(
+            {
+                'html': application_link
+            })
         %}
-        {% endif %}
 
 		{% set rows = ns.rows.append(row)%}
 
@@ -90,13 +93,11 @@
         %}
 	{% endif %}
 
-	{% if not is_past_submission_deadline %}
-		{% set app = application_headings.append(
-            {
-            'text': gettext('Action')
-            })
-        %}
-	{% endif %}
+    {% set app = application_headings.append(
+        {
+        'text': gettext('Action')
+        })
+    %}
 
 	{{
             govukTable({

--- a/app/templates/partials/tasklist_section.html
+++ b/app/templates/partials/tasklist_section.html
@@ -1,3 +1,4 @@
+<!-- I'd prefer to not pass everything for the application in here -->
 {% macro derive_status_tag(status_value, application_meta_data, application_status) %}
   {% set not_started_status = application_meta_data["not_started_status"] %}
   {% set in_progress_status = application_meta_data["in_progress_status"] %}
@@ -18,7 +19,7 @@
   </span>
 {% endmacro %}
 
-{% macro tasklist_section(section, application_meta_data, application_status, index, existing_feedback_map) %}
+{% macro tasklist_section(section, application_meta_data, application_status, index, existing_feedback_map, application) %}
 <li>
     <h2 class="app-task-list__section">
       {{ section["section_title"] }}

--- a/app/templates/partials/tasklist_section.html
+++ b/app/templates/partials/tasklist_section.html
@@ -1,4 +1,3 @@
-<!-- I'd prefer to not pass everything for the application in here -->
 {% macro derive_status_tag(status_value, application_meta_data, application_status) %}
   {% set not_started_status = application_meta_data["not_started_status"] %}
   {% set in_progress_status = application_meta_data["in_progress_status"] %}
@@ -19,7 +18,7 @@
   </span>
 {% endmacro %}
 
-{% macro tasklist_section(section, application_meta_data, application_status, index, existing_feedback_map, application) %}
+{% macro tasklist_section(section, application_meta_data, application_status, index, existing_feedback_map) %}
 <li>
     <h2 class="app-task-list__section">
       {{ section["section_title"] }}

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -28,6 +28,26 @@
             }}</span>
         <h1 class="govuk-heading-xl">{% trans %}Application for{% endtrans %} {{ application_meta_data["fund_title"] }}</h1>
         {% endif %}
+
+
+        {% if application["status"] == application_meta_data["submitted_status"] %}
+            <div class="govuk-grid-row .assessment-alert">
+                <div class="assessment-alert govuk-!-margin-bottom-8">
+                    <h2 class="assessment-alert__heading govuk-heading-l govuk-!-margin-top-4">{% trans %}Application submitted{% endtrans %}</h2>
+                    <p class="govuk-body">{% trans %}You have submitted your application, you cannot change your answers.{% endtrans %}</p>
+                    <p class="govuk-body">{% trans %}Window closed{% endtrans %} {{ submission_deadline|string_to_datetime|datetime_format_full_month }}</p>
+
+                    <dl>
+                        <dt class="govuk-heading-s dl-inline">{% trans %}Status:{% endtrans %}</dt>
+                        <dd class="govuk-body govuk-!-margin-bottom-2"> Submitted on {{ application_submitted_at|datetime_format_full_month }}</dd>
+
+                        <dt class="govuk-heading-s dl-inline">{% trans %}Reference:{% endtrans %}</dt>
+                        <dd class="govuk-body govuk-!-margin-bottom-2"> {{ application["reference"] }}</dd>
+                    </dl>
+                </div>
+            </div>
+
+        {% else %}
         <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
@@ -134,6 +154,7 @@
 
             </div>
         </details>
+
         {% if is_past_submission_deadline %}
         {{ round_closed_warning(fund_name, round_title, submission_deadline) }}
         {% endif %}
@@ -182,9 +203,11 @@
         </dl>
         {% endif %}
 
+        {% endif %}
+
         <ol class="app-task-list">
             {% for section in sections %}
-            {{ tasklist_section(section, application_meta_data, application_status, loop.index, existing_feedback_map)
+            {{ tasklist_section(section, application_meta_data, application_status, loop.index, existing_feedback_map, application)
           }}
             {% endfor %}
             {% if feedback_survey_data %}

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -29,7 +29,6 @@
         <h1 class="govuk-heading-xl">{% trans %}Application for{% endtrans %} {{ application_meta_data["fund_title"] }}</h1>
         {% endif %}
 
-
         {% if application["status"] == application_meta_data["submitted_status"] %}
             <div class="govuk-grid-row .assessment-alert">
                 <div class="assessment-alert govuk-!-margin-bottom-8">
@@ -39,7 +38,7 @@
 
                     <dl>
                         <dt class="govuk-heading-s dl-inline">{% trans %}Status:{% endtrans %}</dt>
-                        <dd class="govuk-body govuk-!-margin-bottom-2"> Submitted on {{ application_submitted_at|datetime_format_full_month }}</dd>
+                        <dd class="govuk-body govuk-!-margin-bottom-2"> Submitted on {{ application.date_submitted|string_to_datetime_ms|datetime_format_full_month }}</dd>
 
                         <dt class="govuk-heading-s dl-inline">{% trans %}Reference:{% endtrans %}</dt>
                         <dd class="govuk-body govuk-!-margin-bottom-2"> {{ application["reference"] }}</dd>
@@ -207,7 +206,7 @@
 
         <ol class="app-task-list">
             {% for section in sections %}
-            {{ tasklist_section(section, application_meta_data, application_status, loop.index, existing_feedback_map, application)
+            {{ tasklist_section(section, application_meta_data, application_status, loop.index, existing_feedback_map)
           }}
             {% endfor %}
             {% if feedback_survey_data %}

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -6,9 +6,7 @@ from app.models.application_display_mapping import ApplicationMapping
 from app.models.fund import Fund
 from bs4 import BeautifulSoup
 from tests.api_data.test_data import SUBMITTED_APPLICATION
-from tests.api_data.test_data import TEST_APPLICATION_SUMMARIES
 from tests.api_data.test_data import TEST_APPLICATIONS
-from tests.api_data.test_data import TEST_DISPLAY_DATA
 from tests.api_data.test_data import TEST_FUNDS_DATA
 from tests.utils import get_language_cookie_value
 

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -55,38 +55,19 @@ def test_tasklist_route_after_deadline(flask_test_client, mocker, mock_login, mo
         return_value=RoundStatus(True, False, False),
     )
     response = flask_test_client.get("tasklist/test-application-id", follow_redirects=False)
-    assert response.status_code == 302
-    assert "/account" == response.location
+    assert response.status_code == 200
+    assert b"Window closed - " in response.data
+    assert b"You can no longer submit applications in this window." in response.data
 
 
-def test_tasklist_for_submit_application_route(flask_test_client, mocker, mock_login):
+def test_tasklist_for_submit_application_route(flask_test_client, mocker, mock_login, mock_applications):
     mocker.patch(
         "app.default.application_routes.get_application_data",
         return_value=SUBMITTED_APPLICATION,
     )
-    mocker.patch(
-        "app.default.application_routes.determine_round_status",
-        return_value=RoundStatus(False, False, True),
-    )
-
-    get_apps_mock = mocker.patch(
-        "app.default.account_routes.search_applications",
-        return_value=TEST_APPLICATION_SUMMARIES,
-    )
-    mocker.patch(
-        "app.default.account_routes.build_application_data_for_display",
-        return_value=TEST_DISPLAY_DATA,
-    )
-    response = flask_test_client.get("tasklist/test-application-submit", follow_redirects=True)
+    response = flask_test_client.get("tasklist/test-application-id", follow_redirects=False)
     assert response.status_code == 200
-    get_apps_mock.assert_called_once_with(
-        search_params={
-            "account_id": "test-user",
-            "fund_id": "111",
-            "round_id": "fsd-r2w2",
-        },
-        as_dict=False,
-    )
+    assert b"You have submitted your application, you cannot change your answers." in response.data
 
 
 def test_language_cookie_update_welsh_to_english(flask_test_client, mocker, mock_login, mock_applications):


### PR DESCRIPTION
### Change description
This change allows the `/tasklist` route to load for funds that have
been closed and applications that have been otherwise submitted.
Additionally we check to see if those conditions are true and pass a new
flag `is_read_only_summary` to the form runner which will present that
tasklist sections summary screen without the option to modify your
answers.

This should allow applicants to see answers they've previously submitted
for complete submissions as well as for rounds in the past.

Functionality depends on https://github.com/communitiesuk/digital-form-builder/pull/551

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes
New view/ continue application behaviour:
![image](https://github.com/user-attachments/assets/52f53bc3-4fbb-43df-a071-2f500c8798f0)

An application that has already been submitted now shown with “View application”
![image](https://github.com/user-attachments/assets/74c46fa6-67b4-42bc-90e0-8bb2cd6a803f)

