### PR TITLE
Adding round close notification page and relevant validations before directing the page to the user.

### DIFF
--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -369,6 +369,10 @@ def continue_application(application_id):
     args = request.args
     form_name = args.get("form_name")
     return_url = request.host_url + url_for("application_routes.tasklist", application_id=application_id)[1:]
+    round_close_notification_url = (
+        request.host_url
+        + url_for("application_routes.fund_round_close_notification", application_id=application_id)[1:]
+    )
     current_app.logger.info(f"Url the form runner should return to '{return_url}'.")
 
     application = get_application_data(application_id)
@@ -377,11 +381,12 @@ def continue_application(application_id):
     form_data = application.get_form_data(application, form_name)
 
     rehydrate_payload = format_rehydrate_payload(
-        form_data,
-        application_id,
-        return_url,
-        form_name,
-        round.mark_as_complete_enabled,
+        form_data=form_data,
+        application_id=application_id,
+        returnUrl=return_url,
+        round_close_notification_url=round_close_notification_url,
+        form_name=form_name,
+        markAsCompleteEnabled=round.mark_as_complete_enabled,
     )
 
     rehydration_token = get_token_to_return_to_application(form_name, rehydrate_payload)

--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from functools import wraps
 from http.client import METHOD_NOT_ALLOWED
 
@@ -151,10 +150,10 @@ def fund_round_close_notification(application_id):
     round_data = get_round_data_without_cache(
         fund_id=application.fund_id, round_id=application.round_id, language=application.language
     )
-    deadline = datetime.strptime(round_data.deadline, "%Y-%m-%dT%H:%M:%S")
+    round_status = determine_round_status(round_data)
     # added this check sometimes if url forcefully change we should not show this notification unless if
     # there is a round close
-    if datetime.now() > deadline:
+    if round_status.past_submission_deadline:
         return render_template(
             "fund-round-notification.html",
             application_id=application_id,

--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import wraps
 from http.client import METHOD_NOT_ALLOWED
 
@@ -11,6 +12,7 @@ from app.default.data import get_feedback_survey_from_store
 from app.default.data import get_fund_data
 from app.default.data import get_research_survey_from_store
 from app.default.data import get_round_data
+from app.default.data import get_round_data_without_cache
 from app.default.data import get_ttl_hash
 from app.default.data import post_feedback_survey_to_store
 from app.default.data import post_research_survey_to_store
@@ -133,6 +135,46 @@ def verify_round_open(f):
             return redirect(url_for("account_routes.dashboard"))
 
     return decorator
+
+
+@application_bp.route("/fund-round/notification/<application_id>", methods=["GET", "POST"])
+@login_required
+@verify_application_owner_local
+def fund_round_close_notification(application_id):
+    application = get_application_data(application_id=application_id)
+    fund_data = get_fund_data(
+        fund_id=application.fund_id,
+        language=application.language,
+        as_dict=False,
+        ttl_hash=get_ttl_hash(Config.LRU_CACHE_TIME),
+    )
+    round_data = get_round_data_without_cache(
+        fund_id=application.fund_id, round_id=application.round_id, language=application.language
+    )
+    deadline = datetime.strptime(round_data.deadline, "%Y-%m-%dT%H:%M:%S")
+    # added this check sometimes if url forcefully change we should not show this notification unless if
+    # there is a round close
+    if datetime.now() > deadline:
+        return render_template(
+            "fund-round-notification.html",
+            application_id=application_id,
+            application_view_url=url_for(
+                "application_routes.tasklist",
+                application_id=application_id,
+            ),
+            dashboard_url=url_for(
+                "account_routes.dashboard",
+                fund=fund_data.short_name,
+                round=round_data.short_name,
+            ),
+            migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
+        )
+    return redirect(
+        url_for(
+            "application_routes.tasklist",
+            application_id=application_id,
+        )
+    )
 
 
 @application_bp.route("/tasklist/<application_id>", methods=["GET"])

--- a/app/default/data.py
+++ b/app/default/data.py
@@ -193,6 +193,13 @@ def get_round_data(fund_id, round_id, language=None, as_dict=False, ttl_hash=Non
         return Round.from_dict(round_response)
 
 
+def get_round_data_without_cache(fund_id, round_id, language=None):
+    language = {"language": language or get_lang()}
+    round_request_url = Config.GET_ROUND_DATA_FOR_FUND_ENDPOINT.format(fund_id=fund_id, round_id=round_id)
+    round_response = get_data(round_request_url, language)
+    return Round.from_dict(round_response)
+
+
 def get_application_display_config(fund_id, round_id, language):
     application_display_request_url = Config.GET_APPLICATION_DISPLAY_FOR_FUND_ENDPOINT.format(
         fund_id=fund_id, round_id=round_id, language=language

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -69,6 +69,7 @@ def format_rehydrate_payload(
     form_data,
     application_id,
     returnUrl,
+    round_close_notification_url,
     form_name,
     markAsCompleteEnabled: bool,
     callback_url=Config.UPDATE_APPLICATION_FORM_ENDPOINT,
@@ -133,6 +134,8 @@ def format_rehydrate_payload(
     formatted_data["metadata"]["fund_name"] = fund_name
     formatted_data["metadata"]["round_name"] = round_name
     formatted_data["metadata"]["has_eligibility"] = has_eligibility
+    if round_close_notification_url is not None:
+        formatted_data["metadata"]["round_close_notification_url"] = round_close_notification_url
 
     return formatted_data
 

--- a/app/templates/fund-round-notification.html
+++ b/app/templates/fund-round-notification.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "partials/migration_banner.html" import migration_banner %}
+
+{% set pageHeading %}{% trans %}Round closed{% endtrans %}{% endset %}
+
+{% block content %}
+    {% if migration_banner_enabled %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {{ migration_banner() }}
+            </div>
+        </div>
+    {% endif %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-thirds">
+            <h1 class="govuk-heading-xl">{% trans %}This application is now closed{% endtrans %}</h1>
+            <div class="govuk-details">
+                <p class="govuk-body">
+                    {% trans %}The deadline to apply for this fund has now passed.{% endtrans %}
+                </p>
+                <p class="govuk-body">
+                    {% trans %}You can still view your application, but you can no longer add new information.{% endtrans %}
+                </p>
+                <a href="{{ application_view_url }}" class="govuk-back-link"> {% trans %}View application{% endtrans %}</a>
+            </div>
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    'text': gettext('Back to all applications'),
+                    "href": dashboard_url
+                }) }}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/app/translations/cy/LC_MESSAGES/messages.po
+++ b/app/translations/cy/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-08 15:29+0100\n"
+"POT-Creation-Date: 2024-10-09 17:48+0100\n"
 "PO-Revision-Date: 2022-10-25 16:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cy\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: app/create_app.py:129 app/default/application_routes.py:301
+#: app/create_app.py:129 app/default/application_routes.py:343
 msgid "Apply for"
 msgstr "Gwneud cais am"
 
@@ -635,6 +635,32 @@ msgstr "Cwcis"
 #: app/templates/footer.html:19
 msgid "Accessibility Statement"
 msgstr "Datganiad Hygyrchedd"
+
+#: app/templates/fund-round-notification.html:5
+msgid "Round closed"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:17
+msgid "This application is now closed"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:20
+msgid "The deadline to apply for this fund has now passed."
+msgstr ""
+
+#: app/templates/fund-round-notification.html:23
+msgid ""
+"You can still view your application, but you can no longer add new "
+"information."
+msgstr ""
+
+#: app/templates/fund-round-notification.html:25
+msgid "View application"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:29
+msgid "Back to all applications"
+msgstr ""
 
 #: app/templates/fund_start_page.html:5
 msgid "Start or continue an"

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-08 15:29+0100\n"
+"POT-Creation-Date: 2024-10-09 17:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: app/create_app.py:129 app/default/application_routes.py:301
+#: app/create_app.py:129 app/default/application_routes.py:343
 msgid "Apply for"
 msgstr ""
 
@@ -574,6 +574,32 @@ msgstr ""
 
 #: app/templates/footer.html:19
 msgid "Accessibility Statement"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:5
+msgid "Round closed"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:17
+msgid "This application is now closed"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:20
+msgid "The deadline to apply for this fund has now passed."
+msgstr ""
+
+#: app/templates/fund-round-notification.html:23
+msgid ""
+"You can still view your application, but you can no longer add new "
+"information."
+msgstr ""
+
+#: app/templates/fund-round-notification.html:25
+msgid "View application"
+msgstr ""
+
+#: app/templates/fund-round-notification.html:29
+msgid "Back to all applications"
 msgstr ""
 
 #: app/templates/fund_start_page.html:5

--- a/tests/test_fund_round_notification.py
+++ b/tests/test_fund_round_notification.py
@@ -1,0 +1,25 @@
+import pytest
+from tests.api_data.test_data import TEST_APPLICATIONS
+from tests.api_data.test_data import TEST_ROUNDS_DATA
+
+TEST_APPLICATION_EN = TEST_APPLICATIONS[0]
+TEST_APPLICATION_CY = TEST_APPLICATIONS[1]
+
+
+@pytest.fixture
+def mock_applications(mocker):
+    mocker.patch("app.default.application_routes.get_application_data", return_value=TEST_APPLICATION_EN)
+
+
+def test_notification_route_after_deadline(flask_test_client, mocker, mock_login, mock_applications):
+    mocker.patch("app.default.application_routes.get_round_data_without_cache", return_value=TEST_ROUNDS_DATA[0])
+    response = flask_test_client.get("/fund-round/notification/test-application-id", follow_redirects=False)
+    assert response.status_code == 200
+    assert b"Round closed - " in response.data
+
+
+def test_notification_route_before_deadline(flask_test_client, mocker, mock_login, mock_applications):
+    mocker.patch("app.default.application_routes.get_round_data_without_cache", return_value=TEST_ROUNDS_DATA[1])
+    response = flask_test_client.get("/fund-round/notification/test-application-id", follow_redirects=False)
+    assert response.status_code == 302
+    assert b"/tasklist/test-application-id" in response.data


### PR DESCRIPTION
Adding round close notification page and relevant validations before directing the page to the user.

https://dluhcdigital.atlassian.net/browse/FS-4666


### Change description
_A brief description of the pull request_

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
When user is in the middle of a application filling process & have a round close same time will show this page


### Screenshots of UI changes (if applicable)

![image](https://github.com/user-attachments/assets/74c8f9a2-7635-4d8c-975c-3e8e1de92745)

