### PR TITLE
FS-4674 Visually indicate funds with the "EOI" funding type

### DIFF
--- a/app/default/application_routes.py
+++ b/app/default/application_routes.py
@@ -264,6 +264,7 @@ def tasklist(application_id):
     application_meta_data = {
         "application_id": application_id,
         "fund_name": fund_data.name,
+        "funding_type": fund_data.funding_type,
         "fund_title": fund_data.title,
         "round_name": round_data.title,
         "application_guidance": round_data.application_guidance,

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -64,7 +64,7 @@ def all_questions(fund_short_name, round_short_name):
 
         template_name = determine_all_questions_template_name(fund_short_name, round_short_name, lang, fund)
         try:
-            fund_title = fund.name + (f"({gettext('Expression of interest')})" if fund.funding_type == "EOI" else "")
+            fund_title = fund.name + (f" - {gettext('Expression of interest')}" if fund.funding_type == "EOI" else "")
             return render_template(
                 template_name,
                 fund_title=fund_title,

--- a/app/default/content_routes.py
+++ b/app/default/content_routes.py
@@ -10,6 +10,7 @@ from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
+from flask_babel import gettext
 from fsd_utils.authentication.decorators import login_requested
 from fsd_utils.locale_selector.get_lang import get_lang
 from jinja2.exceptions import TemplateNotFound
@@ -63,9 +64,10 @@ def all_questions(fund_short_name, round_short_name):
 
         template_name = determine_all_questions_template_name(fund_short_name, round_short_name, lang, fund)
         try:
+            fund_title = fund.name + (f"({gettext('Expression of interest')})" if fund.funding_type == "EOI" else "")
             return render_template(
                 template_name,
-                fund_title=fund.name,
+                fund_title=fund_title,
                 round_title=round.title,
                 migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
             )

--- a/app/models/fund.py
+++ b/app/models/fund.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 class Fund:
     id: str
     name: str
+    funding_type: str
     short_name: str
     description: str
     title: str

--- a/app/templates/dashboard_all.html
+++ b/app/templates/dashboard_all.html
@@ -32,6 +32,9 @@
                 <h2 class="govuk-accordion__section-heading">
                     <span class="govuk-accordion__section-button" id="funds-heading-{{ fund['fund_data']['short_name'] }}">
                         {{ fund["fund_data"]["name"] }}
+                        {% if fund["fund_data"]["funding_type"] == "EOI" %}
+                            ({% trans %}Expression of interest{% endtrans %})
+                        {% endif %}
                     </span>
                 </h2>
             </div>

--- a/app/templates/dashboard_all.html
+++ b/app/templates/dashboard_all.html
@@ -33,7 +33,7 @@
                     <span class="govuk-accordion__section-button" id="funds-heading-{{ fund['fund_data']['short_name'] }}">
                         {{ fund["fund_data"]["name"] }}
                         {% if fund["fund_data"]["funding_type"] == "EOI" %}
-                            ({% trans %}Expression of interest{% endtrans %})
+                            &nbsp;-&nbsp;{% trans %}Expression of interest{% endtrans %}
                         {% endif %}
                     </span>
                 </h2>

--- a/app/templates/dashboard_single_fund.html
+++ b/app/templates/dashboard_single_fund.html
@@ -14,7 +14,7 @@
 {% set fund = display_data["funds"][0] %}
 {% trans %}Your applications for{% endtrans %}  {{ fund["fund_data"]["name"] }}
 {% if fund["fund_data"]["funding_type"] == "EOI" %}
-    ({% trans %}Expression of interest{% endtrans %})
+    &nbsp;-&nbsp;{% trans %}Expression of interest{% endtrans %}
 {% endif %}
 {% else %}
 Your applications
@@ -39,7 +39,7 @@ Your applications
                 <span class="govuk-caption-m">
                     {{ fund["fund_data"]["name"] }}
                     {% if fund["fund_data"]["funding_type"] == "EOI" %}
-                        ({% trans %}Expression of interest{% endtrans %})
+                        &nbsp;-&nbsp;{% trans %}Expression of interest{% endtrans %}
                     {% endif %}
                 </span>
                 <h2 class="govuk-heading-l">

--- a/app/templates/dashboard_single_fund.html
+++ b/app/templates/dashboard_single_fund.html
@@ -11,7 +11,11 @@
 {% extends "base.html" %}
 {% set pageHeading %}
 {% if display_data["funds"] %}
-{% trans %}Your applications for{% endtrans %}  {{ display_data["funds"][0]["fund_data"]["name"] }}
+{% set fund = display_data["funds"][0] %}
+{% trans %}Your applications for{% endtrans %}  {{ fund["fund_data"]["name"] }}
+{% if fund["fund_data"]["funding_type"] == "EOI" %}
+    ({% trans %}Expression of interest{% endtrans %})
+{% endif %}
 {% else %}
 Your applications
 {% endif %}
@@ -32,7 +36,12 @@ Your applications
     {% for fund in display_data["funds"] %}
         {% for round in fund["rounds"] %}
             {% if not round["is_not_yet_open"] %}
-                <span class="govuk-caption-m">{{ fund["fund_data"]["name"] }}</span>
+                <span class="govuk-caption-m">
+                    {{ fund["fund_data"]["name"] }}
+                    {% if fund["fund_data"]["funding_type"] == "EOI" %}
+                        ({% trans %}Expression of interest{% endtrans %})
+                    {% endif %}
+                </span>
                 <h2 class="govuk-heading-l">
                     {{ round["round_details"]["title"] }}
                 </h2>

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -20,7 +20,12 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {% if is_expression_of_interest %}
-        <span class="govuk-caption-l">{{ application_meta_data["fund_name"] }} </span>
+        <span class="govuk-caption-l">
+            {{ application_meta_data["fund_name"] }}
+            {% if application_meta_data["funding_type"] == "EOI" %}
+                ({% trans %}Expression of interest{% endtrans %})
+            {% endif %}
+        </span>
         <h1 class="govuk-heading-xl"> {{ application_meta_data["fund_title"]| replace("expression", "Expression") }}
         </h1>
         {% else %}

--- a/app/templates/tasklist.html
+++ b/app/templates/tasklist.html
@@ -23,7 +23,7 @@
         <span class="govuk-caption-l">
             {{ application_meta_data["fund_name"] }}
             {% if application_meta_data["funding_type"] == "EOI" %}
-                ({% trans %}Expression of interest{% endtrans %})
+                &nbsp;-&nbsp;{% trans %}Expression of interest{% endtrans %}
             {% endif %}
         </span>
         <h1 class="govuk-heading-xl"> {{ application_meta_data["fund_title"]| replace("expression", "Expression") }}

--- a/tests/api_data/test_data.py
+++ b/tests/api_data/test_data.py
@@ -83,6 +83,7 @@ TEST_FUNDS_DATA = [
         "short_name": "FSD",
         "title": "fund for testing",
         "welsh_available": True,
+        "funding_type": "COMPETITIVE",
     },
     {
         "id": "222",
@@ -91,6 +92,7 @@ TEST_FUNDS_DATA = [
         "short_name": "FSD2",
         "title": "fund for testing 2",
         "welsh_available": False,
+        "funding_type": "COMPETITIVE",
     },
     {
         "id": "333",
@@ -99,6 +101,7 @@ TEST_FUNDS_DATA = [
         "short_name": "FSD2",
         "title": "gronfa cymraeg",
         "welsh_available": True,
+        "funding_type": "COMPETITIVE",
     },
 ]
 
@@ -154,6 +157,7 @@ TEST_DISPLAY_DATA = {
                 "name": "Test Fund",
                 "description": "test test",
                 "short_name": "FSD",
+                "funding_type": "COMPETITIVE",
             },
             "rounds": [
                 {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -163,6 +163,7 @@ def test_dashboard_language(
                 "description": "test test",
                 "short_name": "FSD",
                 "title": "fund for testing",
+                "funding_type": "COMPETITIVE",
                 "welsh_available": fund_supports_welsh,
             },
         ),
@@ -207,7 +208,6 @@ def test_dashboard_route(flask_test_client, mocker, mock_login):
         )
         == 0
     )
-    assert len(soup.find_all("span", class_="govuk-caption-m", string="Test Fund")) == 2
     assert len(soup.find_all("h2", string=lambda text: "Round 2 Window 2" == str.strip(text))) == 1
     assert len(soup.find_all("h2", string=lambda text: "Round 2 Window 2" == str.strip(text))) == 1
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from datetime import datetime
 from unittest import mock
 from unittest.mock import ANY
@@ -129,7 +130,7 @@ def test_dashboard_eoi_suffix(
     mock_login,
     mocker,
 ):
-    eoi_data = TEST_DISPLAY_DATA.copy()
+    eoi_data = deepcopy(TEST_DISPLAY_DATA)
     eoi_data["funds"][0]["fund_data"]["funding_type"] = "EOI"
     mocker.patch(
         "app.default.account_routes.search_applications",
@@ -141,7 +142,7 @@ def test_dashboard_eoi_suffix(
 
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert "(Expression of interest)" in soup.find("h2", class_="govuk-accordion__section-heading").get_text()
+    assert "Expression of interest" in soup.find("h2", class_="govuk-accordion__section-heading").get_text()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -13,6 +13,7 @@ def test_get_fund_data_lru_cache(mocker):
         "welsh_available": True,
         "title": "Test Fund by ID",
         "id": "222",
+        "funding_type": "COMPETITIVE",
     }
     mocker.patch(
         "app.default.data.get_data",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -57,6 +57,7 @@ fund_args = {
     "short_name": "",
     "description": "",
     "welsh_available": True,
+    "funding_type": "COMPETITIVE",
 }
 short_name_fund = Fund(**fund_args, title="Test Fund by short name", id="111")
 id_fund = Fund(**fund_args, title="Test Fund by ID", id="222")


### PR DESCRIPTION
### Change description
Now that funds have the `funding_type` property add a visual indiciation any time that we show the "noun" fund "name" property on the dashboard pages.

Note this isn't the same as the "titles" properties which usually are verbs and translated.

Future fund models may model the EOI as a proprety on the fund but for now the questions and configuration for expression of interests are effectively modelled as funds themselves.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

### Screenshots of UI changes

<img width="1271" alt="Screenshot 2024-10-17 at 16 52 22" src="https://github.com/user-attachments/assets/82bc0554-7762-46e1-9c3c-9d0e7fe05379">
<img width="1271" alt="Screenshot 2024-10-17 at 16 52 26" src="https://github.com/user-attachments/assets/fc3ae3e9-8067-4b12-a81b-72ea6b429530">
<img width="1271" alt="Screenshot 2024-10-17 at 16 52 52" src="https://github.com/user-attachments/assets/b35942c2-859d-48ac-aaac-a20373d81ecc">
<img width="1271" alt="Screenshot 2024-10-17 at 16 52 59" src="https://github.com/user-attachments/assets/be26c711-ebe9-4493-a35a-78f9c5a78815">

