### PR TITLE
Update support email to communities from levellingup

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -23,7 +23,7 @@
                 }}
             {% else %}
                 {{ contact_details(
-                    "fsd.support@levellingup.gov.uk",
+                    "fundingservice.support@communities.gov.uk",
                     "",
                     "",
                     "9am to 5pm",

--- a/app/templates/accessibility_statement.html
+++ b/app/templates/accessibility_statement.html
@@ -30,7 +30,7 @@
                 {% trans %}additional manual testing and our responses to the findings of these activities.{% endtrans %}</p>
             <h2 class="govuk-heading-m">{% trans %}Feedback and contact information{% endtrans %}</h2>
             <p class="govuk-body">{% trans %}If you find any problems that are not listed on this page or you think we’re not meeting the accessibility requirements,{% endtrans %}
-                <a href="mailto:fsd.support@levellingup.gov.uk" class="govuk-link">{% trans %}contact us{% endtrans %}</a>.</p>
+                <a href="mailto:fundingservice.support@communities.gov.uk" class="govuk-link">{% trans %}contact us{% endtrans %}</a>.</p>
             <h2 class="govuk-heading-m">{% trans %}Enforcement procedure{% endtrans %}</h2>
             <p class="govuk-body">{% trans %}The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).{% endtrans %}</p>
             <p class="govuk-body">{% trans %}If you’re not happy with how we respond to your complaint,{% endtrans %}

--- a/app/templates/contact_us.html
+++ b/app/templates/contact_us.html
@@ -30,7 +30,7 @@
 
             {% if round_data %}
                 {{ contact_details(
-                            round_data.contact_email if not round_data.contact_us_banner else "fsd.support@levellingup.gov.uk",
+                            round_data.contact_email if not round_data.contact_us_banner else "fundingservice.support@communities.gov.uk",
                             round_data.contact_phone,
                             round_data.contact_phone,
                             round_data.support_days,
@@ -39,7 +39,7 @@
                 }}
             {% else %}
                 {{ contact_details(
-                    "fsd.support@levellingup.gov.uk",
+                    "fundingservice.support@communities.gov.uk",
                     "",
                     "",
                     "9am to 5pm",

--- a/app/templates/research_opt_in.html
+++ b/app/templates/research_opt_in.html
@@ -29,7 +29,7 @@
 
             <p class="govuk-body">{% trans %}Taking part in research will not affect the outcomes of your application.{% endtrans %}</p>
 
-            <p class="govuk-body">{% trans %}You can always say no to an invite, and can withdraw your consent to be contacted or to use your data at any time. To do so, please contact us at {% endtrans %}<a class="govuk-link" href="mailto:fsd.support@levellingup.gov.uk">fsd.support@levellingup.gov.uk</a>. </p>
+            <p class="govuk-body">{% trans %}You can always say no to an invite, and can withdraw your consent to be contacted or to use your data at any time. To do so, please contact us at {% endtrans %}<a class="govuk-link" href="mailto:fundingservice.support@communities.gov.uk">fundingservice.support@communities.gov.uk</a>. </p>
 
             <form class="form" method="post">
                 {{ form.hidden_tag() }}

--- a/tests/test_content_routes.py
+++ b/tests/test_content_routes.py
@@ -17,12 +17,12 @@ from bs4 import BeautifulSoup
         ),
         (
             "/contact_us?fund=bad&round=bad",
-            "fsd.support@levellingup.gov.uk",
+            "fundingservice.support@communities.gov.uk",
             "Contact us if you have any questions.",
         ),
         (
             "/contact_us",
-            "fsd.support@levellingup.gov.uk",
+            "fundingservice.support@communities.gov.uk",
             "Contact us if you have any questions.",
         ),
     ],

--- a/tests/test_error_routes.py
+++ b/tests/test_error_routes.py
@@ -71,7 +71,7 @@ def test_404_with_bad_fund(client, mocker):
     response = client.get("not_found?fund=bad_fund&round=r2w2")
     assert response.status_code == 404
     soup = BeautifulSoup(response.data, "html.parser")
-    assert "fsd.support@levellingup.gov.uk" in soup.find("li").text
+    assert "fundingservice.support@communities.gov.uk" in soup.find("li").text
 
 
 def test_404_with_bad_round(client, mocker):
@@ -101,7 +101,7 @@ def test_404_with_bad_fund_n_round(client, mocker):
     response = client.get("not_found?fund=bad_fund&round=bad_round_id")
     assert response.status_code == 404
     soup = BeautifulSoup(response.data, "html.parser")
-    assert "fsd.support@levellingup.gov.uk" in soup.find("li").text
+    assert "fundingservice.support@communities.gov.uk" in soup.find("li").text
 
 
 def test_unauthorised_error(client, mocker):
@@ -127,4 +127,4 @@ def test_unauthorised_error_with_bad_fund_n_round(client, mocker):
     response = client.get("unauthorised_error?fund=bad_fund&round=bad_round_id")
     assert response.status_code == 404
     soup = BeautifulSoup(response.data, "html.parser")
-    assert "fsd.support@levellingup.gov.uk" in soup.find("li").text
+    assert "fundingservice.support@communities.gov.uk" in soup.find("li").text


### PR DESCRIPTION
### Change description
The old support email was using the levellingup domain ( fsd.support@levellingup.gov.uk ). This has been updated to the fundingservice.support@communities.gov.uk

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
