### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,7 @@ debugpy
 dparse>=0.5.2
 black
 deepdiff
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -144,7 +144,9 @@ flipper-client==1.3.2
     #   -r requirements.txt
     #   funding-service-design-utils
 funding-service-design-utils[toggles]==5.1.1
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   funding-service-design-utils
 govuk-frontend-jinja==2.7.0
     # via -r requirements.txt
 gunicorn==20.1.0
@@ -216,7 +218,7 @@ platformdirs==4.1.0
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.6.0
+pre-commit==4.0.1
     # via -r requirements-dev.in
 pycodestyle==2.11.1
     # via flake8
@@ -238,6 +240,7 @@ pyjwt[crypto]==2.8.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
+    #   pyjwt
 pyproject-hooks==1.0.0
     # via build
 pyscss==1.4.0
@@ -307,6 +310,7 @@ sentry-sdk[flask]==2.14.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
+    #   sentry-sdk
 six==1.16.0
     # via
     #   -r requirements.txt
@@ -344,6 +348,7 @@ tomli==2.0.1
     #   dparse
     #   flake8-pyproject
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
     #   pytest-env
 typing-extensions==4.9.0


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.