### PR TITLE
FLS-795: Added nginx sidecar for basic auth

### DIFF
--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -134,7 +134,6 @@ environments:
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-
   prod:
     http:
       alias: frontend.access-funding.levellingup.gov.uk

--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -68,6 +68,22 @@ environments:
   dev:
     count:
       spot: 1
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   test:
     deployment:
       rolling: 'recreate'

--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -119,6 +119,22 @@ environments:
         value: 80
       requests: 30
       response_time: 2s
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   prod:
     http:
       alias: frontend.access-funding.levellingup.gov.uk

--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -108,6 +108,10 @@ environments:
   uat:
     http:
       alias: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
     count:
       range: 2-4
       cooldown:
@@ -130,11 +134,7 @@ environments:
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-    http:
-      target_container: nginx
-      healthcheck:
-        path: /healthcheck
-        port: 8080
+      
   prod:
     http:
       alias: frontend.access-funding.levellingup.gov.uk

--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -89,6 +89,22 @@ environments:
       rolling: 'recreate'
     count:
       spot: 2
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
   uat:
     http:
       alias: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"

--- a/copilot/fsd-frontend/manifest.yml
+++ b/copilot/fsd-frontend/manifest.yml
@@ -134,7 +134,7 @@ environments:
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-      
+
   prod:
     http:
       alias: frontend.access-funding.levellingup.gov.uk


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-795


### Change description
- Added sidecar to enable basic auth

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Visit the apply test envs, you should be prompted to provide useranme and password


### Screenshots of UI changes (if applicable)