### PR TITLE
Remove pipeline deploy path filters

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -29,19 +29,6 @@ on:
         type: boolean
         description: Run e2e tests (application)
   push:
-    # Ignore README markdown and the docs folder
-    # Only automatically deploy when something in the app or tests folder has changed
-    paths:
-      - '!**/README.md'
-      - '!docs/**'
-      - 'app/**'
-      - 'config/**'
-      - 'tests/**'
-      - 'requirements-dev.in'
-      - 'requirements-dev.txt'
-      - 'requirements.in'
-      - 'requirements.txt'
-      - '.github/workflows/copilot_deploy.yml'
 
 jobs:
   setup:


### PR DESCRIPTION
It's really annoying to not have a pipeline trigger when you expect it to, and unless this list of paths is fiercly kept accurate/up-to-date then inevitably someone will get caught off guard.

That someone is me - right now. :(