### PR TITLE
FLS-813: Eligibility result route updated

### DIFF
--- a/app/default/eligibility_routes.py
+++ b/app/default/eligibility_routes.py
@@ -14,10 +14,12 @@ from fsd_utils.authentication.decorators import login_required
 eligibility_bp = Blueprint("eligibility_routes", __name__, template_folder="templates")
 
 
-@eligibility_bp.route("/eligibility-result/<fund_short_name>/<round_name>", methods=["GET"])
+@eligibility_bp.route("/eligibility-result", methods=["GET"])
 @login_required
-def eligiblity_result(fund_short_name, round_name):
+def eligiblity_result():
     """Render the eligibility result page"""
+    fund_short_name = request.args.get("fund_name")
+    round_name = request.args.get("round_name")
     current_app.logger.info(f"Eligibility launch result: {fund_short_name} {round_name}")
     return_url = request.host_url + url_for("account_routes.dashboard", fund=fund_short_name, round=round_name)
     fund, round = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_name)

--- a/app/default/eligibility_routes.py
+++ b/app/default/eligibility_routes.py
@@ -14,12 +14,16 @@ from fsd_utils.authentication.decorators import login_required
 eligibility_bp = Blueprint("eligibility_routes", __name__, template_folder="templates")
 
 
-@eligibility_bp.route("/eligibility-result", methods=["GET"])
+@eligibility_bp.route("/eligibility-result/<fund_short_name>/<round_name>", methods=["GET"])
 @login_required
-def eligiblity_result():
+def eligiblity_result(fund_short_name, round_name):
     """Render the eligibility result page"""
-    fund_short_name = request.args.get("fund_name")
-    round_name = request.args.get("round_name")
+    redirect_to_eligible_round = request.args.get("redirect_to_eligible_round")
+
+    # change round name if redirect_to_eligible_round is set in coming request from form runner
+    if redirect_to_eligible_round:
+        round_name = redirect_to_eligible_round
+
     current_app.logger.info(f"Eligibility launch result: {fund_short_name} {round_name}")
     return_url = request.host_url + url_for("account_routes.dashboard", fund=fund_short_name, round=round_name)
     fund, round = get_fund_and_round(fund_short_name=fund_short_name, round_short_name=round_name)

--- a/tests/test_eligibility_routes.py
+++ b/tests/test_eligibility_routes.py
@@ -1,0 +1,71 @@
+from app.models.fund import Fund
+from app.models.round import Round
+
+default_hsra_round_fields = {
+    "opens": "2022-09-01T00:00:01",
+    "assessment_deadline": "2030-03-20T00:00:01",
+    "contact_us_banner": "",
+    "contact_email": "test@example.com",
+    "contact_phone": "123456789",
+    "contact_textphone": "123456789",
+    "support_times": "9-5",
+    "support_days": "Mon-Fri",
+    "prospectus": "/hsra_rp_prospectus",
+    "instructions": "Round specific instruction text",
+    "privacy_notice": "http://privacy.com",
+    "project_name_field_id": "",
+    "feedback_link": "http://feedback.com",
+    "application_guidance": "",
+    "mark_as_complete_enabled": False,
+    "is_expression_of_interest": False,
+    "eligibility_config": {"has_eligibility": True},
+}
+
+default_hsra_fund_fields = {
+    "id": "444",
+    "name": "HSRA",
+    "description": "test HSRA Fund",
+    "short_name": "HSRA",
+    "title": "High Street Rental Funds",
+    "welsh_available": False,
+    "funding_type": "COMPETITIVE",
+}
+
+
+def test_eligibility_result(client, mocker, mock_login, templates_rendered):
+    def mock_fund_and_round(short_name, round_id, title):
+        mocker.patch(
+            "app.helpers.get_fund_data_by_short_name",
+            return_value=Fund.from_dict(default_hsra_fund_fields),
+        )
+        mocker.patch(
+            "app.helpers.get_round_data_by_short_names",
+            return_value=Round.from_dict(
+                {
+                    **default_hsra_round_fields,
+                    "fund_id": "444",
+                    "id": round_id,
+                    "short_name": short_name,
+                    "title": title,
+                    "deadline": "2050-01-01T00:00:01",
+                }
+            ),
+        )
+
+    # Test eligibility result with redirect_to_eligible_round parameter
+    mock_fund_and_round("RP", "hsra-rp", "Refurbishment Project")
+    result = client.get("eligibility-result/hsra/vr?redirect_to_eligible_round=RP")
+    assert result.status_code == 200
+    assert len(templates_rendered) == 1
+    rendered_template = templates_rendered[0]
+    assert rendered_template[0].name == "eligibility_result.html"
+    assert rendered_template[1]["round_id"] == "hsra-rp"
+
+    # Test eligibility result without redirect_to_eligible_round parameter
+    mock_fund_and_round("VR", "hsra-vr", "Vacancy Register")
+    result = client.get("eligibility-result/hsra/vr")
+    assert result.status_code == 200
+    assert len(templates_rendered) == 2
+    rendered_template = templates_rendered[1]
+    assert rendered_template[0].name == "eligibility_result.html"
+    assert rendered_template[1]["round_id"] == "hsra-vr"


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-813


### Change description
- Updated eligibility result route to get request arguments from the query string passed on from the form runner

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Make sure HSRA VR/RP are live
- Go through the login process
- Click on check eligibility button
- Make sure selecting vacancy register or refurbishment project as answer to question "Why are you applying to this funding?" forwards you to the correct Application tasklist for that round


### Screenshots of UI changes (if applicable)
